### PR TITLE
[P0] common/ を静的ライブラリ化する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,39 @@ find_package(gflags REQUIRED)
 find_package(glog REQUIRED)
 find_package(Boost COMPONENTS filesystem)
 
+# ---------------------------------------------------------------------------
+# Imported targets for the bootstrap-built third-party static libraries.
+# Replaces the raw ${THIRD_PARTY_DIR}/.../*.a paths previously copy-pasted
+# into every protocol's target_link_libraries(...).
+# ---------------------------------------------------------------------------
+add_library(ccbench::masstree STATIC IMPORTED GLOBAL)
+set_target_properties(ccbench::masstree PROPERTIES
+  IMPORTED_LOCATION "${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a")
+
+add_library(ccbench::mimalloc STATIC IMPORTED GLOBAL)
+set_target_properties(ccbench::mimalloc PROPERTIES
+  IMPORTED_LOCATION "${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a")
+
+# ---------------------------------------------------------------------------
+# common/ as a real shared static library — replaces the per-binary
+# duplication that compiled common/result.cc + common/util.cc once per
+# target (~28 duplicate compilations across all protocols × workloads).
+# Protocols just `target_link_libraries(<bin> PRIVATE ccbench_common)`.
+# ---------------------------------------------------------------------------
+add_library(ccbench_common STATIC
+  common/result.cc
+  common/util.cc
+)
+target_include_directories(ccbench_common PUBLIC
+  ${CMAKE_SOURCE_DIR}
+)
+target_link_libraries(ccbench_common PUBLIC
+  Threads::Threads
+  Boost::filesystem
+  gflags::gflags
+  glog::glog
+)
+
 add_subdirectory(cicada)
 add_subdirectory(d2pl)
 add_subdirectory(ermia)

--- a/cicada/CMakeLists.txt
+++ b/cicada/CMakeLists.txt
@@ -3,8 +3,6 @@ include(CMakePackageConfigHelpers)
 include(CompileOptions)
 
 file(GLOB YCSB_CICADA_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "ycsb_cicada.cc"
         "result.cc"
         "transaction.cc"
@@ -12,8 +10,6 @@ file(GLOB YCSB_CICADA_SOURCES
         )
 
 file(GLOB TPCC_CICADA_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "tpcc_cicada.cc"
         "result.cc"
         "transaction.cc"
@@ -21,8 +17,6 @@ file(GLOB TPCC_CICADA_SOURCES
         )
 
 file(GLOB BOMB_CICADA_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "bomb_cicada.cc"
         "result.cc"
         "transaction.cc"
@@ -30,8 +24,6 @@ file(GLOB BOMB_CICADA_SOURCES
         )
 
 file(GLOB SBOMB_CICADA_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "sbomb_cicada.cc"
         "result.cc"
         "transaction.cc"
@@ -43,38 +35,14 @@ add_executable(tpcc_cicada.exe ${TPCC_CICADA_SOURCES})
 add_executable(bomb_cicada.exe ${BOMB_CICADA_SOURCES})
 add_executable(sbomb_cicada.exe ${SBOMB_CICADA_SOURCES})
 
-target_link_libraries(ycsb_cicada.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
 
-target_link_libraries(tpcc_cicada.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(bomb_cicada.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(sbomb_cicada.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
+foreach(t ycsb_cicada.exe tpcc_cicada.exe bomb_cicada.exe sbomb_cicada.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
 else ()

--- a/d2pl/CMakeLists.txt
+++ b/d2pl/CMakeLists.txt
@@ -3,8 +3,6 @@ include(CMakePackageConfigHelpers)
 include(CompileOptions)
 
 file(GLOB SBOMB_D2PL_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "sbomb_d2pl.cc"
         "transaction.cc"
@@ -12,8 +10,6 @@ file(GLOB SBOMB_D2PL_SOURCES
         )
 
 file(GLOB DBOMB_D2PL_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "dbomb_d2pl.cc"
         "transaction.cc"
@@ -23,22 +19,14 @@ file(GLOB DBOMB_D2PL_SOURCES
 add_executable(sbomb_d2pl.exe ${SBOMB_D2PL_SOURCES})
 add_executable(bomb_d2pl.exe ${DBOMB_D2PL_SOURCES})
 
-target_link_libraries(sbomb_d2pl.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
 
-target_link_libraries(bomb_d2pl.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
+foreach(t sbomb_d2pl.exe bomb_d2pl.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
 else ()

--- a/ermia/CMakeLists.txt
+++ b/ermia/CMakeLists.txt
@@ -3,8 +3,6 @@ include(CMakePackageConfigHelpers)
 include(CompileOptions)
 
 file(GLOB YCSB_ERMIA_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "ycsb_ermia.cc"
         "garbage_collection.cc"
         "result.cc"
@@ -13,8 +11,6 @@ file(GLOB YCSB_ERMIA_SOURCES
         )
 
 file(GLOB TPCC_ERMIA_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "tpcc_ermia.cc"
         "garbage_collection.cc"
         "result.cc"
@@ -23,8 +19,6 @@ file(GLOB TPCC_ERMIA_SOURCES
         )
 
 file(GLOB BOMB_ERMIA_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "bomb_ermia.cc"
         "garbage_collection.cc"
         "result.cc"
@@ -33,8 +27,6 @@ file(GLOB BOMB_ERMIA_SOURCES
         )
 
 file(GLOB SBOMB_ERMIA_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "sbomb_ermia.cc"
         "garbage_collection.cc"
         "result.cc"
@@ -47,38 +39,14 @@ add_executable(tpcc_ermia.exe ${TPCC_ERMIA_SOURCES})
 add_executable(bomb_ermia.exe ${BOMB_ERMIA_SOURCES})
 add_executable(sbomb_ermia.exe ${SBOMB_ERMIA_SOURCES})
 
-target_link_libraries(ycsb_ermia.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
 
-target_link_libraries(tpcc_ermia.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(bomb_ermia.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(sbomb_ermia.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
+foreach(t ycsb_ermia.exe tpcc_ermia.exe bomb_ermia.exe sbomb_ermia.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
 else ()

--- a/mocc/CMakeLists.txt
+++ b/mocc/CMakeLists.txt
@@ -3,8 +3,6 @@ include(CMakePackageConfigHelpers)
 include(CompileOptions)
 
 file(GLOB YCSB_MOCC_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "lock.cc"
         "ycsb_mocc.cc"
         "result.cc"
@@ -13,8 +11,6 @@ file(GLOB YCSB_MOCC_SOURCES
         )
 
 file(GLOB TPCC_MOCC_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "lock.cc"
         "tpcc_mocc.cc"
         "result.cc"
@@ -23,8 +19,6 @@ file(GLOB TPCC_MOCC_SOURCES
         )
 
 file(GLOB BOMB_MOCC_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "lock.cc"
         "bomb_mocc.cc"
         "result.cc"
@@ -33,8 +27,6 @@ file(GLOB BOMB_MOCC_SOURCES
         )
 
 file(GLOB SBOMB_MOCC_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "lock.cc"
         "sbomb_mocc.cc"
         "result.cc"
@@ -47,38 +39,14 @@ add_executable(tpcc_mocc.exe ${TPCC_MOCC_SOURCES})
 add_executable(bomb_mocc.exe ${BOMB_MOCC_SOURCES})
 add_executable(sbomb_mocc.exe ${SBOMB_MOCC_SOURCES})
 
-target_link_libraries(ycsb_mocc.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
 
-target_link_libraries(tpcc_mocc.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(bomb_mocc.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(sbomb_mocc.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
+foreach(t ycsb_mocc.exe tpcc_mocc.exe bomb_mocc.exe sbomb_mocc.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
 else ()

--- a/mvto/CMakeLists.txt
+++ b/mvto/CMakeLists.txt
@@ -5,8 +5,6 @@ include(CMakePackageConfigHelpers)
 include(CompileOptions)
 
 file(GLOB BOMB_MVTO_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "bomb_mvto.cc"
         "result.cc"
         "transaction.cc"
@@ -14,8 +12,6 @@ file(GLOB BOMB_MVTO_SOURCES
         )
 
 file(GLOB TPCC_MVTO_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "tpcc_mvto.cc"
         "result.cc"
         "transaction.cc"
@@ -25,22 +21,14 @@ file(GLOB TPCC_MVTO_SOURCES
 add_executable(bomb_mvto.exe ${BOMB_MVTO_SOURCES})
 add_executable(tpcc_mvto.exe ${TPCC_MVTO_SOURCES})
 
-target_link_libraries(bomb_mvto.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
 
-target_link_libraries(tpcc_mvto.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
+foreach(t bomb_mvto.exe tpcc_mvto.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
 else ()

--- a/oze/CMakeLists.txt
+++ b/oze/CMakeLists.txt
@@ -5,8 +5,6 @@ include(CompileOptions)
 include_directories(${THIRD_PARTY_DIR}/googletest/googletest/include)
 
 file(GLOB YCSB_OZE_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "ycsb_oze.cc"
         "result.cc"
         "transaction.cc"
@@ -15,8 +13,6 @@ file(GLOB YCSB_OZE_SOURCES
         )
 
 file(GLOB TPCC_OZE_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "tpcc_oze.cc"
         "result.cc"
         "transaction.cc"
@@ -25,8 +21,6 @@ file(GLOB TPCC_OZE_SOURCES
         )
 
 file(GLOB BOMB_OZE_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "bomb_oze.cc"
         "result.cc"
         "transaction.cc"
@@ -38,33 +32,14 @@ add_executable(ycsb_oze.exe ${YCSB_OZE_SOURCES})
 add_executable(tpcc_oze.exe ${TPCC_OZE_SOURCES})
 add_executable(bomb_oze.exe ${BOMB_OZE_SOURCES})
 
-target_link_libraries(ycsb_oze.exe
-        Boost::filesystem
-        gflags::gflags
-        glog::glog
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
 
-target_link_libraries(tpcc_oze.exe
-        Boost::filesystem
-        gflags::gflags
-        glog::glog
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(bomb_oze.exe
-        Boost::filesystem
-        gflags::gflags
-        glog::glog
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
+foreach(t ycsb_oze.exe tpcc_oze.exe bomb_oze.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
 else ()

--- a/si/CMakeLists.txt
+++ b/si/CMakeLists.txt
@@ -3,8 +3,6 @@ include(CMakePackageConfigHelpers)
 include(CompileOptions)
 
 file(GLOB YCSB_SI_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "ycsb_si.cc"
         "garbage_collection.cc"
         "result.cc"
@@ -13,8 +11,6 @@ file(GLOB YCSB_SI_SOURCES
         )
 
 file(GLOB TPCC_SI_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "tpcc_si.cc"
         "garbage_collection.cc"
         "result.cc"
@@ -23,8 +19,6 @@ file(GLOB TPCC_SI_SOURCES
         )
 
 file(GLOB BOMB_SI_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "bomb_si.cc"
         "garbage_collection.cc"
         "result.cc"
@@ -33,8 +27,6 @@ file(GLOB BOMB_SI_SOURCES
         )
 
 file(GLOB SBOMB_SI_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "sbomb_si.cc"
         "garbage_collection.cc"
         "result.cc"
@@ -47,38 +39,14 @@ add_executable(tpcc_si.exe ${TPCC_SI_SOURCES})
 add_executable(bomb_si.exe ${BOMB_SI_SOURCES})
 add_executable(sbomb_si.exe ${SBOMB_SI_SOURCES})
 
-target_link_libraries(ycsb_si.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
 
-target_link_libraries(tpcc_si.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(bomb_si.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(sbomb_si.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
+foreach(t ycsb_si.exe tpcc_si.exe bomb_si.exe sbomb_si.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
 else ()

--- a/silo/CMakeLists.txt
+++ b/silo/CMakeLists.txt
@@ -3,8 +3,6 @@ include(CMakePackageConfigHelpers)
 include(CompileOptions)
 
 file(GLOB YCSB_SILO_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "ycsb_silo.cc"
         "transaction.cc"
@@ -12,8 +10,6 @@ file(GLOB YCSB_SILO_SOURCES
         )
 
 file(GLOB TPCC_SILO_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "tpcc_silo.cc"
         "transaction.cc"
@@ -21,8 +17,6 @@ file(GLOB TPCC_SILO_SOURCES
         )
 
 file(GLOB BOMB_SILO_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "bomb_silo.cc"
         "transaction.cc"
@@ -30,8 +24,6 @@ file(GLOB BOMB_SILO_SOURCES
         )
 
 file(GLOB SBOMB_SILO_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "sbomb_silo.cc"
         "transaction.cc"
@@ -48,37 +40,13 @@ add_executable(bomb_silo.exe ${BOMB_SILO_SOURCES})
 add_executable(sbomb_silo.exe ${SBOMB_SILO_SOURCES})
 add_executable(replay_test.exe ${REPLAY_SOURCES})
 
-target_link_libraries(ycsb_silo.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(tpcc_silo.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(bomb_silo.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(sbomb_silo.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
+foreach(t ycsb_silo.exe tpcc_silo.exe bomb_silo.exe sbomb_silo.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})

--- a/ss2pl/CMakeLists.txt
+++ b/ss2pl/CMakeLists.txt
@@ -3,8 +3,6 @@ include(CMakePackageConfigHelpers)
 include(CompileOptions)
 
 file(GLOB BOMB_SS2PL_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "bomb_ss2pl.cc"
         "transaction.cc"
@@ -12,8 +10,6 @@ file(GLOB BOMB_SS2PL_SOURCES
         )
 
 file(GLOB TPCC_SS2PL_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "tpcc_ss2pl.cc"
         "transaction.cc"
@@ -23,22 +19,14 @@ file(GLOB TPCC_SS2PL_SOURCES
 add_executable(bomb_ss2pl.exe ${BOMB_SS2PL_SOURCES})
 add_executable(tpcc_ss2pl.exe ${TPCC_SS2PL_SOURCES})
 
-target_link_libraries(bomb_ss2pl.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
 
-target_link_libraries(tpcc_ss2pl.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
+foreach(t bomb_ss2pl.exe tpcc_ss2pl.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
 else ()

--- a/tictoc/CMakeLists.txt
+++ b/tictoc/CMakeLists.txt
@@ -3,8 +3,6 @@ include(CMakePackageConfigHelpers)
 include(CompileOptions)
 
 file(GLOB YCSB_TICTOC_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "ycsb_tictoc.cc"
         "transaction.cc"
@@ -12,8 +10,6 @@ file(GLOB YCSB_TICTOC_SOURCES
         )
 
 file(GLOB TPCC_TICTOC_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "tpcc_tictoc.cc"
         "transaction.cc"
@@ -21,8 +17,6 @@ file(GLOB TPCC_TICTOC_SOURCES
         )
 
 file(GLOB BOMB_TICTOC_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "bomb_tictoc.cc"
         "transaction.cc"
@@ -30,8 +24,6 @@ file(GLOB BOMB_TICTOC_SOURCES
         )
 
 file(GLOB SBOMB_TICTOC_SOURCES
-        "../common/result.cc"
-        "../common/util.cc"
         "result.cc"
         "sbomb_tictoc.cc"
         "transaction.cc"
@@ -43,38 +35,14 @@ add_executable(tpcc_tictoc.exe ${TPCC_TICTOC_SOURCES})
 add_executable(bomb_tictoc.exe ${BOMB_TICTOC_SOURCES})
 add_executable(sbomb_tictoc.exe ${SBOMB_TICTOC_SOURCES})
 
-target_link_libraries(ycsb_tictoc.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
 
-target_link_libraries(tpcc_tictoc.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(bomb_tictoc.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
-target_link_libraries(sbomb_tictoc.exe
-        Boost::filesystem
-        gflags::gflags
-        ${THIRD_PARTY_DIR}/mimalloc/out/release/libmimalloc.a
-        ${THIRD_PARTY_DIR}/masstree/libkohler_masstree_json.a
-        Threads::Threads
-        )
-
+foreach(t ycsb_tictoc.exe tpcc_tictoc.exe bomb_tictoc.exe sbomb_tictoc.exe)
+    target_link_libraries(${t} PRIVATE
+            ccbench_common
+            ccbench::masstree
+            ccbench::mimalloc
+            )
+endforeach()
 if (DEFINED ADD_ANALYSIS)
     add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
 else ()


### PR DESCRIPTION
Closes #30.

## What

Top-level `CMakeLists.txt`:
- `add_library(ccbench_common STATIC common/result.cc common/util.cc)`.
  PUBLIC link: `Threads / Boost::filesystem / gflags / glog`.
  PUBLIC include: source root (so `../include/foo.hh` resolves transitively).
- Imported targets `ccbench::masstree` and `ccbench::mimalloc` for the
  bootstrap-built static archives — replaces the raw
  `\${THIRD_PARTY_DIR}/.../*.a` paths.

Each protocol's `CMakeLists.txt`:
- Drop `"../common/result.cc"` and `"../common/util.cc"` from `file(GLOB)`.
- Replace the per-binary `target_link_libraries(<bin> ... )` blocks with a
  single `foreach(t <bins...>) target_link_libraries(\${t} PRIVATE
  ccbench_common ccbench::masstree ccbench::mimalloc) endforeach()`.

CRLF -> LF on `silo/ss2pl/cicada/mocc/ermia/CMakeLists.txt`.

## Why

\`common/result.cc\` and \`common/util.cc\` were being recompiled separately for every one of the 28 binaries. ccache was masking the duplication; the CI workflow's own comment was candid about it.

## Verified

- All 34 binaries build (Release, Debug+ASan).
- \`common/{result,util}.cc.o\` now produced **exactly once** per build directory (was 28 times).
- Smoke runs of \`tpcc_<protocol>.exe\` across silo/mocc/cicada/ermia/tictoc/oze/ss2pl/mvto/si all return non-zero throughput.
- Debug+ASan smoke of tpcc_silo (4t/4wh) and tpcc_si (4t/4wh) clean apart from the pre-existing MVCC version leak (unrelated to this change).

## Out of scope (tracked separately)

- per-protocol \`result.cc\` / \`util.cc\` still per-protocol — P2 (#33).
- \`add_definitions(...)\` blocks unchanged — P4 (#37).
- \`cc_format/\` untouched — P5 (#34).
- \`oze/\` still has a \`THIRD_PARTY_DIR\` reference for googletest include — P8 territory (#37).

## Diff highlights

\`\`\`
 CMakeLists.txt        |  +33
 silo/CMakeLists.txt   | -286 -> -100ish (similar pattern across 9 protocols)
 11 files changed, +1027 -1247
\`\`\`