### PR TITLE
devcontainer: Ubuntu 24.04 (GCC 13) に上げて CI と compiler を一致させる

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,17 @@
 # Force linux/amd64 because the codebase uses x86-only intrinsics
 # (e.g. __cpuid_count in include/cpu.hh). On Apple Silicon this runs
 # under QEMU emulation: fine for build/edit/test, not for benchmarking.
-FROM --platform=linux/amd64 ubuntu:24.04
+#
+# Two stages published as two tags:
+#   - `base` -> :ci    (minimal — what CI's build.yml actually needs)
+#   - `dev`  -> :latest (`base` + human-facing tools used in the
+#                       devcontainer: zsh shell, clang-format, sudo,
+#                       openssh-client, curl)
+#
+# Keeping the CI image slim means container init in GitHub Actions
+# only has to pull the base layers, which is where the speedup vs the
+# old "apt-get install on every run" workflow comes from.
+FROM --platform=linux/amd64 ubuntu:24.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
@@ -15,8 +25,8 @@ RUN sed -i \
     && rm -f /etc/apt/apt.conf.d/docker-clean \
     && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-# Install build dependencies. Under QEMU emulation the bottleneck is dpkg
-# post-install scripts, not download speed, so apt-fast doesn't help here.
+# Build-time deps used by *both* CI and the devcontainer. Don't add
+# convenience tools here — those live in the `dev` stage below.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
@@ -27,17 +37,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libtool \
         pkg-config \
         git \
-        openssh-client \
         ca-certificates \
-        sudo \
-        curl \
         ccache \
-        clang-format \
         cmake \
         libboost-filesystem-dev \
         libgflags-dev \
-        libgoogle-glog-dev \
-        zsh
+        libgoogle-glog-dev
 
 ARG USERNAME=vscode
 ARG USER_UID=1000
@@ -45,12 +50,35 @@ ARG USER_GID=1000
 
 # Ubuntu 24.04 ships a default `ubuntu` user at uid=1000, which collides
 # with our useradd below. Remove it first; the `|| true` keeps this
-# tolerant of older bases that don't have it.
+# tolerant of older bases that don't have one.
 RUN userdel -r ubuntu 2>/dev/null || true \
     && groupadd --gid ${USER_GID} ${USERNAME} \
-    && useradd --uid ${USER_UID} --gid ${USER_GID} -m -s /bin/bash ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m -s /bin/bash ${USERNAME}
+
+WORKDIR /workspaces/ccbench
+
+# CI uses the base stage as-is (root, no extra tooling). It overrides
+# WORKDIR and user from the workflow file.
+
+
+# ---------------------------------------------------------------------------
+# `dev` stage: adds the things a human needs but CI doesn't care about.
+# Published as :latest and referenced by .devcontainer/devcontainer.json.
+# ---------------------------------------------------------------------------
+FROM base AS dev
+
+ARG USERNAME=vscode
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        zsh \
+        clang-format \
+        sudo \
+        openssh-client \
+        curl \
     && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/${USERNAME} \
     && chmod 0440 /etc/sudoers.d/${USERNAME}
 
 USER ${USERNAME}
-WORKDIR /workspaces/ccbench

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 # Force linux/amd64 because the codebase uses x86-only intrinsics
 # (e.g. __cpuid_count in include/cpu.hh). On Apple Silicon this runs
 # under QEMU emulation: fine for build/edit/test, not for benchmarking.
-FROM --platform=linux/amd64 ubuntu:22.04
+FROM --platform=linux/amd64 ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
@@ -43,7 +43,11 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=1000
 
-RUN groupadd --gid ${USER_GID} ${USERNAME} \
+# Ubuntu 24.04 ships a default `ubuntu` user at uid=1000, which collides
+# with our useradd below. Remove it first; the `|| true` keeps this
+# tolerant of older bases that don't have it.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && groupadd --gid ${USER_GID} ${USERNAME} \
     && useradd --uid ${USER_UID} --gid ${USER_GID} -m -s /bin/bash ${USERNAME} \
     && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/${USERNAME} \
     && chmod 0440 /etc/sudoers.d/${USERNAME}

--- a/.github/workflows/devcontainer-image.yml
+++ b/.github/workflows/devcontainer-image.yml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/devcontainer-image.yml'
   workflow_dispatch:
 
+# The Dockerfile is multi-stage. We publish the dev stage as :latest
+# (what humans `Reopen in Container` into) and the slimmer base stage
+# as :ci (what build.yml runs the build job inside). Both share layers
+# via the same :cache image.
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -25,22 +29,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v6
-        id: meta
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/ccbench-devcontainer
-          tags: |
-            type=raw,value=latest
-            type=sha,format=short
-
-      - uses: docker/build-push-action@v7
+      # dev stage -> :latest (devcontainer)
+      - name: Build & push dev image (:latest)
+        uses: docker/build-push-action@v7
         with:
           context: .devcontainer
           file: .devcontainer/Dockerfile
+          target: dev
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ghcr.io/${{ github.repository_owner }}/ccbench-devcontainer:latest
+          provenance: false
+          sbom: false
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/ccbench-devcontainer:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/ccbench-devcontainer:cache,mode=max
+
+      # base stage -> :ci (used by build.yml's container job)
+      - name: Build & push CI image (:ci)
+        uses: docker/build-push-action@v7
+        with:
+          context: .devcontainer
+          file: .devcontainer/Dockerfile
+          target: base
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/ccbench-devcontainer:ci
           provenance: false
           sbom: false
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/ccbench-devcontainer:cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,31 +134,9 @@ if (stat != Status::OK) return false;   // do not skip this
 - **Debug+ASan** (the default top-level Debug build) is the right mode for correctness work — most TPC-C bugs we have caught (use-after-free in `get_and_update_*`, the `cast_to<Order>` assertion, the gcRecord UAF) showed up there first and were invisible under pure Release.
 - **Release** is for benchmark numbers only. CI builds Release without sanitizer (`-DENABLE_SANITIZER=OFF`) — it does not run binaries, just verifies they compile.
 
-### Compiler-version mismatch with CI
+### Compiler version
 
-CI runs on `ubuntu-latest` (currently Ubuntu 24.04 → **GCC 13**). The default devcontainer ships **GCC 11**. The two compilers disagree on `-Wmaybe-uninitialized` (and likely other flow-sensitive warnings): GCC 13 catches false-positive-prone cases that GCC 11 lets through.
-
-When working on the phased `-Werror` cleanup (#43) — or anything else that promotes a warning to error — **verify on GCC 13 locally before pushing**. Three rounds of CI red on PR #44 (`-Wmaybe-uninitialized`) were avoidable by doing this once. Options:
-
-```sh
-# Option 1: PPA (one-time setup, fastest iteration afterwards)
-sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-sudo apt-get update && sudo apt-get install -y gcc-13 g++-13
-CC=gcc-13 CXX=g++-13 cmake -S . -B build-gcc13 -DCMAKE_BUILD_TYPE=Release -DENABLE_SANITIZER=OFF
-cmake --build build-gcc13 -j
-```
-
-```sh
-# Option 2: Docker (no host changes; slower because deps re-install each run)
-docker run --rm -v "$PWD":/ccbench -w /ccbench ubuntu:24.04 bash -c '
-  apt-get update && apt-get install -y --no-install-recommends \
-    $(cat build_tools/ubuntu.deps) build-essential pkg-config && \
-  cmake -S . -B build-gcc13 -DCMAKE_BUILD_TYPE=Release -DENABLE_SANITIZER=OFF && \
-  cmake --build build-gcc13 -j
-'
-```
-
-Pushing a `-Werror=<flag>` promotion without a GCC 13 build first counts as "didn't actually verify."
+Both the devcontainer (`ubuntu:24.04` base, see [.devcontainer/Dockerfile](.devcontainer/Dockerfile)) and CI (`ubuntu-latest`) ship **GCC 13**, so what builds in the devcontainer also builds in CI. This wasn't always true — see #44, where GCC 11 in an older devcontainer disagreed with CI's GCC 13 on `-Wmaybe-uninitialized` and burned three CI cycles before the gap was closed.
 
 ## Repository layout
 


### PR DESCRIPTION
## 背景

[#44](https://github.com/thawk105/ccbench/pull/44) で `-Werror=maybe-uninitialized` を有効化した際、CI (GCC 13) でだけ落ちる箇所が **3 ラウンド** 出て、毎回 push して CI 待ち → fix のループに陥った（cicada `pre_ver`、mocc `threshold`、silo `LogRecord` padding）。原因は **devcontainer が ubuntu:22.04 = GCC 11** で、CI の `ubuntu-latest` = GCC 13 と flow-sensitive 警告の挙動が一致していなかったこと。

ついでに、[#46](https://github.com/thawk105/ccbench/pull/46) で「CI を devcontainer image の中で走らせれば apt install が消えて高速化できる」と試したところ、image に dev 専用ツール (zsh / clang-format / sudo / openssh-client / curl) が乗っていて **container init で +15s** 食われ、ネットでは逆に遅くなっていた。

この PR でその両方を根本対応する:

1. devcontainer base を **ubuntu:22.04 → ubuntu:24.04**。`g++` が GCC 13.x に解決され、CI と一致
2. Dockerfile を **multi-stage 化** し、image を 2 タグに分けて publish:
   - `:latest` (= dev stage) ← devcontainer 用、zsh/clang-format/sudo/openssh-client/curl 入り (今まで通り)
   - `:ci` (= base stage) ← CI 用、上記 dev ツールなしの slim 版

## 変更

- `.devcontainer/Dockerfile`: `ubuntu:22.04` → `ubuntu:24.04`、Multi-stage (`base` + `dev`) に分割。base stage で `userdel -r ubuntu 2>/dev/null || true` を入れて 24.04 のデフォルト ubuntu ユーザー (uid=1000) と vscode の衝突を回避。`--platform=linux/amd64` 維持で Apple Silicon QEMU 動作は変わらず。
- `.github/workflows/devcontainer-image.yml`: `docker/build-push-action` を 2 回呼び、`target: dev` を `:latest` に、`target: base` を `:ci` に push。layer cache は `:cache` tag で共有。
- `CLAUDE.md`: #44 で追加した "Compiler-version mismatch with CI" workaround セクションを 1 行 ("both ship GCC 13") に縮約。

## 認証

ghcr image は **public** (anonymous bearer-token pull で manifest 取得可能、HTTP 200)。CI 側でも `credentials:` 不要。

## 検証

- [x] GCC 13 ローカルビルド (PPA から `gcc-13/g++-13` インストール、#44 の `-Werror=maybe-uninitialized` 込みで全 34 バイナリ成功)
- [ ] master merge 後に `:latest` と `:ci` 両方が ghcr に publish される
- [ ] master merge 後に devcontainer を Rebuild Container して GCC 13 環境に切り替わる
- [ ] `:ci` tag が publish されたら、#46 を rebase + container.image を `:ci` に切り替える follow-up PR を出す

## トレードオフ

| 観点 | Before | After |
|---|---|---|
| devcontainer の GCC | 11 (22.04) | 13 (24.04) |
| dev tooling (zsh, clang-format, sudo, openssh-client, curl) | あり | あり (`:latest`) |
| CI で使う image | (CI は apt install) | `:ci` (slim) — `:latest` の重い layers を pull せずに済む |
| image build 時間 | 1 stage | 2 stage (キャッシュ共有で実質変わらず) |

## Related

- #43 (phased -Werror cleanup): GCC 一致は前提条件
- #46 (CI を devcontainer image で動かす): この PR マージ後に `:ci` 切り替え