### PR TITLE
CI: ghcr の devcontainer image でビルドして apt install を省く

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,15 @@ jobs:
     # (Ubuntu base + apt deps + ccache + GCC already installed). This drops
     # the per-run `apt-get install` step and the apt cache that used to wrap
     # it, and guarantees the CI toolchain matches the devcontainer's.
+    #
+    # --user root: the devcontainer image's default user is vscode (uid=1000),
+    # but the GHA runner's work dir (/__w/_temp, bind-mounted into the
+    # container) is owned by the runner user on the host. Without root the
+    # action's housekeeping writes (e.g. actions/checkout's saveState) hit
+    # EACCES. Running as root inside the container is fine — it's isolated.
     container:
       image: ghcr.io/thawk105/ccbench-devcontainer:latest
+      options: --user root
     timeout-minutes: 30
     env:
       # Pin ccache dir so actions/cache and ccache agree on the path.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,14 @@ jobs:
         with:
           submodules: recursive
 
+      # actions/checkout writes its own safe.directory, but later steps
+      # invoke git from a fresh shell (`sh -e {0}`) where that scoped
+      # config is not always picked up. Set it once globally so every
+      # `git ...` call in this job — checkout's submodule walk, the
+      # bootstrap-key step, etc. — sees the workspace as safe.
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       # ccache deduplicates compilations across the 34 binaries (each
       # protocol's CMakeLists.txt currently compiles common/*.cc and its
       # own .cc files separately for every target).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Run the job inside the same devcontainer image developers use locally
+    # (Ubuntu base + apt deps + ccache + GCC already installed). This drops
+    # the per-run `apt-get install` step and the apt cache that used to wrap
+    # it, and guarantees the CI toolchain matches the devcontainer's.
+    container:
+      image: ghcr.io/thawk105/ccbench-devcontainer:latest
     timeout-minutes: 30
     env:
       # Pin ccache dir so actions/cache and ccache agree on the path.
@@ -30,24 +36,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache apt packages
-        id: apt-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            /var/cache/apt/archives/*.deb
-            /var/cache/apt/archives/partial/*.deb
-          key: apt-${{ runner.os }}-${{ hashFiles('build_tools/ubuntu.deps') }}
-
-      - name: Install apt dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends \
-            $(cat build_tools/ubuntu.deps) \
-            build-essential autoconf automake libtool pkg-config \
-            ccache
-
-      # ccache deduplicates compilations across the 28 binaries (each
+      # ccache deduplicates compilations across the 34 binaries (each
       # protocol's CMakeLists.txt currently compiles common/*.cc and its
       # own .cc files separately for every target).
       - name: Restore ccache


### PR DESCRIPTION
## 概要

`build.yml` の job を [`ghcr.io/thawk105/ccbench-devcontainer:latest`](https://github.com/thawk105/ccbench/pkgs/container/ccbench-devcontainer) の中で実行するようにする。devcontainer image にはすでに `build-essential / autoconf / automake / libtool / pkg-config / ccache / cmake / libboost-filesystem-dev / libgflags-dev / libgoogle-glog-dev / g++` が揃っているので、毎回の `apt-get install` (現状 30秒〜1分) とそれを包むための apt cache 操作が丸ごと不要になる。

副次効果として、**CI のツールチェインが手元の devcontainer と完全に同じ image** になり、#44 で起きた「local だと通るのに CI で落ちる」型の事故も構造的に消える。

## 変更

```diff
   build:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/thawk105/ccbench-devcontainer:latest

-      - name: Cache apt packages
-        ...
-      - name: Install apt dependencies
-        ...
+    (削除)
```

## 認証

ghcr image は **public**:

```sh
$ curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:thawk105/ccbench-devcontainer:pull" \
    | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])'
…anonymous token…

$ curl -sI -H "Authorization: Bearer $TOKEN" \
    -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
    https://ghcr.io/v2/thawk105/ccbench-devcontainer/manifests/latest
HTTP/2 200
content-type: application/vnd.docker.distribution.manifest.v2+json
```

anonymous bearer-token pull が通るので、`credentials:` セクションは不要。

## トレードオフ

- **+**: apt install (~30〜60s) + apt-cache restore/save が消える
- **+**: 手元 devcontainer と toolchain が同一になる
- **−**: 代わりに image pull (1回 数秒〜10秒) が初手に入る。実際の数値は CI runner の Docker layer cache 状況に依る。GHA runner では layer は per-runner で揮発的だが、同一 image を別 job で連続 pull すると数秒で済む
- **−**: image が壊れたタイミングで CI が回らなくなるリスク。これは devcontainer-image.yml の rebuild 経路でしか起きないので、`.devcontainer/**` を触るときだけ注意すれば良い

## 注意点 (#45 との関係)

[#45](https://github.com/thawk105/ccbench/pull/45) (devcontainer を ubuntu:22.04 → 24.04 に bump) と独立。

- #45 マージ **前** にこの PR をマージ → CI は古い 22.04 image (GCC 11) で走る。`-Werror=maybe-uninitialized` は GCC 11 で false negative なだけで build は通る (緑のまま)
- #45 マージ **後** にこの PR をマージ → 新 24.04 image (GCC 13) で走る (本来の意図)

どちらの順序でも壊れない。

## Test plan

- [x] image が public で anonymous pull できることを確認
- [ ] CI 緑
- [ ] 旧 build.yml と新 build.yml の所要時間を比較 (apt install ステップ ~30〜60s が消えるはず)