### PR TITLE
Phase 1: -Wunused-but-set-variable を潰して -Werror=unused-but-set-variable を有効化

### DIFF
--- a/cc/cicada/transaction.cc
+++ b/cc/cicada/transaction.cc
@@ -359,12 +359,9 @@ Status TxExecutor::delete_record(Storage s, std::string_view key) {
   }
 
   Tuple* tuple;
-  bool rmw;
-  rmw = false;
   ReadElement<Tuple> *re;
   re = searchReadSet(s, key);
   if (re) {
-    rmw = true;
     tuple = re->rcdptr_;
   } else {
     tuple = Masstrees[get_storage(s)].get_value(key);

--- a/cc/oze/include/transaction.hh
+++ b/cc/oze/include/transaction.hh
@@ -623,7 +623,6 @@ OUT:
     uint64_t get_read_version_cardinality() {
         // only for statistics
         TxSet txns;
-        auto itr = read_set_.begin();
         for (auto re : read_set_) {
             txns.emplace(re.txid_);
         }

--- a/cmake/ProtocolHelpers.cmake
+++ b/cmake/ProtocolHelpers.cmake
@@ -48,7 +48,8 @@ function(ccbench_add_protocol name)
     # fixed. Append the next entry here when its source-level cleanup
     # PR lands.
     target_compile_options(${target} PRIVATE
-      -Werror=maybe-uninitialized)
+      -Werror=maybe-uninitialized
+      -Werror=unused-but-set-variable)
 
     set_property(TARGET ${target} PROPERTY CCBENCH_PROTOCOL "${name}")
     set_property(TARGET ${target} PROPERTY CCBENCH_WORKLOAD "${wl}")

--- a/include/dbomb_deterministic.hh
+++ b/include/dbomb_deterministic.hh
@@ -132,7 +132,11 @@ RETRY:
       std::map<uint32_t,Node*> verify_bom;
 
       tx.reconnoiter_begin(); // Do target selection as if read from cache
-      auto ret = BombWorkload<Tuple,Param>::select_im_by_factory(tx, f_id, product_ids);
+      // Reconnoiter pass: this call's job is to fill product_ids. The
+      // Status is intentionally discarded — if it aborted, product_ids
+      // is just empty or partial and the build_bom_tree loop below
+      // propagates the abort.
+      (void) BombWorkload<Tuple,Param>::select_im_by_factory(tx, f_id, product_ids);
       for (auto& p_id : product_ids) {
         Node* root = BombWorkload<Tuple,Param>::build_bom_tree(tx, p_id);
         if (root == nullptr) ERR;
@@ -194,7 +198,10 @@ RETRY:
         }
       }
 
-      ret = BombWorkload<Tuple,Param>::select_im_by_factory(tx, f_id, verify_products);
+      // Verify pass: see comment on the first select_im_by_factory call
+      // above — Status is discarded by design, downstream code propagates
+      // any abort.
+      (void) BombWorkload<Tuple,Param>::select_im_by_factory(tx, f_id, verify_products);
       for (auto& p_id : verify_products) {
         Node* root = BombWorkload<Tuple,Param>::build_bom_tree(tx, p_id);
         if (root == nullptr) ERR;


### PR DESCRIPTION
[#43](https://github.com/thawk105/ccbench/issues/43) Phase 1 の続き。`-Wmaybe-uninitialized` ([#44](https://github.com/thawk105/ccbench/pull/44)) に続いて、`-Wunused-but-set-variable` (3 件) を潰し、同 PR で `ccbench_add_protocol()` に `-Werror=unused-but-set-variable` を追加する。

## 修正

### 1. `cc/cicada/transaction.cc:362` (`TxExecutor::delete_record`)

```diff
 Tuple* tuple;
-bool rmw;
-rmw = false;
 ReadElement<Tuple> *re;
 re = searchReadSet(s, key);
 if (re) {
-  rmw = true;
   tuple = re->rcdptr_;
 } else {
```

`rmw` は false→true で設定されるが後続で全く参照されない。同ファイル冒頭の `TxExecutor::update()` では `rmw` を `write_set_.emplace_back(..., rmw)` や `rmw ? OpType::RMW : OpType::UPDATE` で本当に使うが、`delete_record` ではコピペ漏れで使い忘れている。3 行まるごと削除。

### 2. `include/dbomb_deterministic.hh:135, :201`

```diff
 tx.reconnoiter_begin();
-auto ret = BombWorkload<Tuple,Param>::select_im_by_factory(tx, f_id, product_ids);
+// Reconnoiter pass: this call's job is to fill product_ids. The
+// Status is intentionally discarded — if it aborted, product_ids
+// is just empty or partial and the build_bom_tree loop below
+// propagates the abort.
+(void) BombWorkload<Tuple,Param>::select_im_by_factory(tx, f_id, product_ids);
 ...
-ret = BombWorkload<Tuple,Param>::select_im_by_factory(tx, f_id, verify_products);
+// Verify pass: see comment on the first select_im_by_factory call
+// above — Status is discarded by design, downstream code propagates
+// any abort.
+(void) BombWorkload<Tuple,Param>::select_im_by_factory(tx, f_id, verify_products);
```

reconnoiter pass / verify pass のどちらも `select_im_by_factory` の目的は `product_ids` (resp. `verify_products`) を埋めることであり、Status は後続の `build_bom_tree(...)` と `std::equal(product_ids, verify_products)` の比較で間接的に伝播する設計。他の callsite ([include/bomb.hh:688](../blob/master/include/bomb.hh#L688) など) と違って明示的な `if (stat != Status::OK) return` が要らない reconnoiter フェーズ特有の事情なので、`(void)` キャスト + コメントで意図を明示。

### 3. `cc/oze/include/transaction.hh:626` (`TxExecutor::get_read_version_cardinality`)

```diff
 uint64_t get_read_version_cardinality() {
     TxSet txns;
-    auto itr = read_set_.begin();
     for (auto re : read_set_) {
         txns.emplace(re.txid_);
     }
     return txns.size();
 }
```

`itr` を取って捨て、その下の range-based for が `read_set_` を直接舐めている。`itr` は完全に未使用。削除。

## CMake

```diff
 target_compile_options(${target} PRIVATE
-  -Werror=maybe-uninitialized)
+  -Werror=maybe-uninitialized
+  -Werror=unused-but-set-variable)
```

## Test plan

- [x] **GCC 13** で `cmake -B build-gcc13 -DCMAKE_BUILD_TYPE=Release -DENABLE_SANITIZER=OFF && cmake --build build-gcc13 -j` → 34/34 (`-Werror=unused-but-set-variable` 越え)
- [x] **GCC 11 + Debug + ASan** (`cmake -B build -DCMAKE_BUILD_TYPE=Debug`) → 34/34
- [ ] CI 緑