### PR TITLE
CI: container image を :ci (slim) に切り替え (#46 の取りこぼし)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,18 +19,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Run the job inside the same devcontainer image developers use locally
-    # (Ubuntu base + apt deps + ccache + GCC already installed). This drops
-    # the per-run `apt-get install` step and the apt cache that used to wrap
-    # it, and guarantees the CI toolchain matches the devcontainer's.
+    # Run the job inside the slim CI image (sibling of the human-facing
+    # :latest devcontainer image — same base layers, dev-only tooling
+    # like zsh/clang-format/sudo/openssh-client stripped out). Both tags
+    # are built and pushed from the same multi-stage Dockerfile by
+    # .github/workflows/devcontainer-image.yml.
     #
-    # --user root: the devcontainer image's default user is vscode (uid=1000),
-    # but the GHA runner's work dir (/__w/_temp, bind-mounted into the
-    # container) is owned by the runner user on the host. Without root the
-    # action's housekeeping writes (e.g. actions/checkout's saveState) hit
-    # EACCES. Running as root inside the container is fine — it's isolated.
+    # --user root: the image's default is vscode (uid=1000), but the
+    # GHA runner's work dir (/__w/_temp, bind-mounted into the container)
+    # is owned by the runner user on the host. Without root, actions'
+    # housekeeping writes (e.g. actions/checkout's saveState) hit EACCES.
+    # Running as root inside the container is fine — it's isolated.
     container:
-      image: ghcr.io/thawk105/ccbench-devcontainer:latest
+      image: ghcr.io/thawk105/ccbench-devcontainer:ci
       options: --user root
     timeout-minutes: 30
     env:


### PR DESCRIPTION
[#46](https://github.com/thawk105/ccbench/pull/46) で CI を devcontainer image の中で動かすようにしたが、merge 時点で `container.image:` の **`:latest` → `:ci` 切り替え commit が force-push のリベース中に落ちて**マージされていなかった。master では今も `:latest` (= zsh / clang-format / sudo / openssh-client / curl 入りの fat image) を pull している。

機能的には `:latest` ⊃ `:ci` (同じ multi-stage Dockerfile の `dev` stage と `base` stage) なので CI 自体は緑のままだが、毎回の image pull で dev ツール layer を引いていて目的の slim 化が達成されていない。

## 変更

```diff
     container:
-      image: ghcr.io/thawk105/ccbench-devcontainer:latest
+      image: ghcr.io/thawk105/ccbench-devcontainer:ci
       options: --user root
```

コメントも `:latest` 文脈から `:ci` 文脈に書き直し。

## なぜローカル確認なしか

`:ci` tag は [#45](https://github.com/thawk105/ccbench/pull/45) でmasterマージ後に既に publish 済み (ghcr.io から anonymous pull で manifest HTTP 200 が返ることを確認済み)。違いは pull する layer set だけで、ビルド成功するかは GHA の container job が image を pull できるかの一点に集約される。なので CI 一発で検証可能。

## Test plan

- [ ] CI 緑 (= `:ci` tag が pull できることの実証)