### PR TITLE
CI: ghcr の untagged image を毎回 prune して GC 不在を補う

### DIFF
--- a/.github/workflows/devcontainer-image.yml
+++ b/.github/workflows/devcontainer-image.yml
@@ -58,3 +58,18 @@ jobs:
           sbom: false
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/ccbench-devcontainer:cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/ccbench-devcontainer:cache,mode=max
+
+      # Every push above re-points :latest / :ci / :cache to fresh
+      # digests; the prior digests stay around forever as untagged
+      # versions because ghcr does no automatic GC. Trim them so the
+      # package's "Versions" UI stays useful. tagged versions (i.e.
+      # :latest, :ci, :cache themselves) are never touched.
+      - name: Prune untagged image versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ccbench-devcontainer
+          package-type: container
+          # keep the 10 most recent untagged digests as a safety
+          # margin (e.g. for rolling back a bad image push).
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: 'true'


### PR DESCRIPTION
ghcr.io は **自動 GC をしない** ので、`devcontainer-image.yml` が master push のたびに `:latest` / `:ci` / `:cache` を上書き push すると、過去 push 分の digest が untagged のまま蓄積し続ける。

public package のストレージは無料なので課金的には実害ゼロだが:

- パッケージの Versions UI が古い digest で溢れて現役がどれか分かりづらい
- bad image push の rollback で「ひとつ前の digest どれだっけ」が探しにくくなる

`devcontainer-image.yml` の最後に prune step を 1 つ追加して、毎回の push 後に untagged を間引く。

## 変更

```yaml
- name: Prune untagged image versions
  uses: actions/delete-package-versions@v5
  with:
    package-name: ccbench-devcontainer
    package-type: container
    min-versions-to-keep: 10
    delete-only-untagged-versions: 'true'
```

## 安全性

- `delete-only-untagged-versions: 'true'` — **tagged version (`:latest`, `:ci`, `:cache`) には絶対触らない**
- `min-versions-to-keep: 10` — untagged のうち最新 10 個は残す。rollback の余地
- 既存の `permissions: { packages: write }` で delete 権限はカバー済み

## なぜ自動化するか

issue としては小さい (UI 美観 + rollback 楽さ程度) が、

- 手動掃除は忘れる
- 数百 untagged 溜まると delete-package-versions の `min-versions-to-keep` の挙動 (ページング) が読みづらくなる前に間引きたい
- 1 ステップで済む

## Test plan

- [ ] master merge 後の最初の `.devcontainer/**` 変更時に workflow が走り、prune ステップが untagged version を削除する
- [ ] tagged (`:latest`/`:ci`/`:cache`) は touch されない