### PR TITLE
Phase 1: -Wunused-label を潰して -Werror=unused-label を有効化 (Phase 1 完了)

### DIFF
--- a/cc/d2pl/transaction.cc
+++ b/cc/d2pl/transaction.cc
@@ -168,9 +168,6 @@ void TxExecutor::read_internal(Storage s, std::string_view key, Tuple* tuple) {
    */
   body = TupleBody(tuple->body_.get_key(), tuple->body_.get_val(), tuple->body_.get_val_align());
   read_set_.emplace_back(s, key, tuple, std::move(body));
-
-FINISH_READ:
-  return;
 }
 
 Status TxExecutor::scan(const Storage s,

--- a/cc/mocc/transaction.cc
+++ b/cc/mocc/transaction.cc
@@ -484,7 +484,6 @@ Status TxExecutor::delete_record(Storage s, std::string_view key) {
 
   write_set_.emplace_back(s, key, tuple, OpType::DELETE);
 
-FINISH_DELETE:
 #if ADD_ANALYSIS
   result_->local_write_latency_ += rdtscp() - start;
 #endif

--- a/cc/mvto/transaction.cc
+++ b/cc/mvto/transaction.cc
@@ -221,7 +221,6 @@ Status TxExecutor::delete_record(Storage s, std::string_view key) {
 
   write_set_.emplace_back(s, key, tuple, nullptr, new_ver, OpType::DELETE);
 
-  FINISH_DELETE:
 #if ADD_ANALYSIS
   result_->local_write_latency_ += rdtscp() - start;
 #endif  // if ADD_ANALYSIS

--- a/cc/oze/transaction.cc
+++ b/cc/oze/transaction.cc
@@ -820,7 +820,6 @@ bool TxExecutor::write_validation(WriteElement<Tuple> element, KeySet& finished_
         return true;
     }
 
-FINISH_VALIDATION:
 #if ADD_ANALYSIS
     result_->local_write_validation_latency_ += rdtscp() - start;
 #endif  // if ADD_ANALYSIS
@@ -998,7 +997,6 @@ bool TxExecutor::read_validation(KeySet& target_set, KeySet& finished_set) {
         }
     }
 
-FINISH_VALIDATION:
 #if DEBUG_MSG
     std::cout << "TxID " << this->txid_ << " read page validation done" << std::endl;
 #endif

--- a/cc/tictoc/transaction.cc
+++ b/cc/tictoc/transaction.cc
@@ -162,7 +162,6 @@ Status TxExecutor::read_internal(Storage s, std::string_view key, Tuple* tuple) 
   this->appro_commit_ts_ = max(this->appro_commit_ts_, v1.wts);
   read_set_.emplace_back(s, key, tuple, std::move(b), v1);
 
-FINISH_READ:
   return Status::OK;
 }
 

--- a/cmake/ProtocolHelpers.cmake
+++ b/cmake/ProtocolHelpers.cmake
@@ -49,7 +49,8 @@ function(ccbench_add_protocol name)
     # PR lands.
     target_compile_options(${target} PRIVATE
       -Werror=maybe-uninitialized
-      -Werror=unused-but-set-variable)
+      -Werror=unused-but-set-variable
+      -Werror=unused-label)
 
     set_property(TARGET ${target} PROPERTY CCBENCH_PROTOCOL "${name}")
     set_property(TARGET ${target} PROPERTY CCBENCH_WORKLOAD "${wl}")

--- a/include/bomb_pessimistic.hh
+++ b/include/bomb_pessimistic.hh
@@ -619,7 +619,7 @@ public:
         ItemMaster::CreateKey(node->i_id_, item.ptr());
         Status stat = tx.read_lock(Storage::ItemMaster, item.view());
         if (stat != Status::OK) {
-          std:stringstream ss; ss << "item id: " << node->i_id_;
+          std::stringstream ss; ss << "item id: " << node->i_id_;
           dump(tx.thid_, ss.str());
           return nullptr;
         }


### PR DESCRIPTION
[#43](https://github.com/thawk105/ccbench/issues/43) Phase 1 の最後の 1 つ。`-Wunused-label` (7 件) を潰し、`ccbench_add_protocol()` に `-Werror=unused-label` を追加する。**Phase 1 これで完了**。

うち **6 件は dead label** の整理、**1 件は `std:` typo の真のバグ修正**。

## Dead labels (6 件)

複数の関数で同名の `FINISH_*` ラベルが定義されていて、片方の関数では `goto` で使われているが、もう片方では `goto` 参照が一切ない。各 warning 位置の **囲み関数を確認した上で、その関数内で実際に未使用のもののみ削除**。同名でも別関数の現役 `goto` target は触らない。

| ファイル:行 | ラベル | 囲み関数 |
|---|---|---|
| [cc/d2pl/transaction.cc:172](../blob/master/cc/d2pl/transaction.cc#L172) | `FINISH_READ` | `read_internal` |
| [cc/mocc/transaction.cc:487](../blob/master/cc/mocc/transaction.cc#L487) | `FINISH_DELETE` | `delete_record` |
| [cc/mvto/transaction.cc:224](../blob/master/cc/mvto/transaction.cc#L224) | `FINISH_DELETE` | `delete_record` |
| [cc/oze/transaction.cc:823](../blob/master/cc/oze/transaction.cc#L823) | `FINISH_VALIDATION` | `write_validation` |
| [cc/oze/transaction.cc:1001](../blob/master/cc/oze/transaction.cc#L1001) | `FINISH_VALIDATION` | `read_validation` |
| [cc/tictoc/transaction.cc:165](../blob/master/cc/tictoc/transaction.cc#L165) | `FINISH_READ` | `read_internal` |

いずれも「関数末尾で `LABEL: <ADD_ANALYSIS の計測コード>; return ...;`」の形。通常制御フローでそこに到達していたので、ラベル削除のみで動作は同じ。

## Real bug (1 件)

[include/bomb_pessimistic.hh:622](../blob/master/include/bomb_pessimistic.hh#L622):

```diff
 if (stat != Status::OK) {
-  std:stringstream ss; ss << "item id: " << node->i_id_;
+  std::stringstream ss; ss << "item id: " << node->i_id_;
   dump(tx.thid_, ss.str());
   return nullptr;
 }
```

**コロン一つ抜けで、GCC は `std:` を unused label と解釈して通してしまっていた**。`stringstream` 自体がスコープに見えていたのは [cc/ss2pl/bomb_ss2pl.cc:25](../blob/master/cc/ss2pl/bomb_ss2pl.cc#L25) の `using namespace std;` のせい — 起きる場所が ss2pl 経由の template instantiation だけだったので、`bomb_ss2pl` 系をビルドした時のみ表面化していた。

`-Werror=unused-label` を有効化したからこそ掘り起こされた、というのは [#43](https://github.com/thawk105/ccbench/issues/43) の趣旨そのもの。

## CMake

```diff
 target_compile_options(${target} PRIVATE
   -Werror=maybe-uninitialized
   -Werror=unused-but-set-variable
+  -Werror=unused-label)
```

## Test plan

- [x] **GCC 13** Release / `-DENABLE_SANITIZER=OFF`: 34/34
- [x] **GCC 11** Debug + ASan: 34/34
- [ ] CI 緑

## Phase 1 完了サマリ

| Warning | PR | 件数 | 内訳 |
|---|---|---|---|
| `-Wmaybe-uninitialized` | [#44](https://github.com/thawk105/ccbench/pull/44) | 1 | oze の uninitialized ScanRange union (実バグ) |
| `-Wunused-but-set-variable` | [#47](https://github.com/thawk105/ccbench/pull/47) | 3 | cicada/dbomb/oze の dead set |
| `-Wunused-label` | この PR | 7 | dead label 6 + `std::` typo 1 |
| **計** | | **11** | |

ロードマップ通り **件数少 + 危険度高** から潰した。次は Phase 2 (`-Wignored-qualifiers` 30 件 → `-Wsign-compare` 61 件)。