### PR TITLE
devcontainer: htop を dev stage に追加 + apt list を両 stage とも ABC sort

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,18 +31,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential \
         autoconf \
         automake \
-        libtool \
-        pkg-config \
-        git \
+        build-essential \
         ca-certificates \
         ccache \
         cmake \
+        git \
         libboost-filesystem-dev \
         libgflags-dev \
-        libgoogle-glog-dev
+        libgoogle-glog-dev \
+        libtool \
+        pkg-config
 
 ARG USERNAME=vscode
 ARG USER_UID=1000
@@ -73,11 +73,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        zsh \
         clang-format \
-        sudo \
-        openssh-client \
         curl \
+        htop \
+        openssh-client \
+        sudo \
+        zsh \
     && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/${USERNAME} \
     && chmod 0440 /etc/sudoers.d/${USERNAME}
 


### PR DESCRIPTION
並列 worktree subagent でビルドを回しているときの CPU 使用率を眺める用に `htop` を入れたい。ついでに base / dev 両 stage の `apt-get install` リストを ABC 順に並べ替えて、htop も正しい位置 (curl と openssh-client の間) に挿入。

## 変更

### dev stage

```diff
     && apt-get install -y --no-install-recommends \
-        zsh \
         clang-format \
-        sudo \
-        openssh-client \
         curl \
+        htop \
+        openssh-client \
+        sudo \
+        zsh \
```

### base stage (CI の `:ci` でも使われる)

```diff
     && apt-get install -y --no-install-recommends \
-        build-essential \
         autoconf \
         automake \
-        libtool \
-        pkg-config \
-        git \
+        build-essential \
         ca-certificates \
         ccache \
         cmake \
+        git \
         libboost-filesystem-dev \
         libgflags-dev \
-        libgoogle-glog-dev
+        libgoogle-glog-dev \
+        libtool \
+        pkg-config
```

## なぜ ABC sort

[Docker 公式のベストプラクティス](https://docs.docker.com/build/building/best-practices/#sort-multi-line-arguments) で multi-line args は sort せよと推奨されている:

- 重複追加を防ぐ (今回 htop を入れるときに既にあるか alphabetical なら一目で確認可能)
- merge conflict が減る (近接位置に追加されにくくなる)
- レビュー時に「これ入ってる?」が探しやすい

## トレードオフ

- `htop` の image size 増分はごく僅か (バイナリ + 依存で数 MB 程度)、dev image にしか入らないので CI 速度には影響なし。
- 並べ替えだけで挙動は変わらない (依存解決順序も apt 側で決まるので install 結果は同一)。

## マージ後の手順

`.devcontainer/**` を触っているので merge で `devcontainer-image.yml` が起動し、`:latest` (dev) と `:ci` (base) の両方が rebuild される。

- devcontainer 側: Rebuild Container すると `htop` が使えるようになる
- CI 側: 動作変わらず (apt 内容自体は同じ、順番だけ変えた)

## Test plan

- [ ] devcontainer-image.yml が走って `:latest` / `:ci` が publish される
- [ ] Rebuild Container 後に `htop` が走る
- [ ] 次の `.devcontainer/**` 外の PR で CI が緑のまま (= base stage の image が壊れていない確認)