### PR TITLE
CLAUDE.md: 「どこに記録するか」(CLAUDE.md/docs vs Claude memory) の指針節を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,33 @@ relevant section before touching a file of that kind.** When you spot
 a convention worth recording, add it there instead of repeating it in
 PR comments.
 
+## Where to record what you learn (CLAUDE.md / docs vs Claude memory)
+
+Claude maintains a **per-project private memory**
+(`~/.claude/projects/.../memory/`) that persists across sessions but
+**is not part of the repository** — it doesn't ship with the clone, no
+other contributor or other Claude instance sees it. CLAUDE.md and
+`docs/` ship with every clone and reach everyone. Pick the right
+destination when recording something new:
+
+- **Goes in this repo (CLAUDE.md / docs/)** if a human contributor would
+  also need it to work effectively on the codebase:
+  - Repository facts (architecture, build flow, protocol matrix, etc.)
+  - Coding conventions adopted by the project
+  - Decision rationale that future maintainers will want to look up
+- **Goes in Claude memory (private to one Claude instance)** if it's
+  personal to how *this* Claude collaborates with *this* user:
+  - User preferences ("reply in Japanese", "no Co-Authored-By trailer")
+  - Claude's own behavioral heuristics (parallelization rules,
+    prompt-writing patterns)
+  - "Last time I made mistake X, the user's fix was Y" — reminders for
+    future Claude turns, not for human review
+
+Rule of thumb: **"would a new contributor cloning the repo need this?"**
+→ yes → repo; → no → memory. Personal preferences and Claude-side
+heuristics specifically **should not** be committed to CLAUDE.md or
+`docs/` — that pollutes the shared repo with one person's taste.
+
 ## What this repo is
 
 CCBench re-implements major in-memory concurrency-control protocols on a common substrate so they can be compared on identical workloads (Tanabe et al., VLDB 2020). The repository now also bundles the **TPC-C** and **BoMB** workloads and several extra protocols, contributed by [@jnmt](https://github.com/jnmt) on the `vldb-paper` branch and merged here.


### PR DESCRIPTION
[#52](https://github.com/thawk105/ccbench/pull/52) の follow-up。

## 動機

Claude には **per-project の private memory** (`~/.claude/projects/.../memory/`) があり、CLAUDE.md / docs とは届く範囲が違う:

- **memory**: 1 Claude インスタンス + 1 ローカル環境のみ。リポを clone した他人や他の Claude には届かない
- **CLAUDE.md / docs**: 全 contributor + 全 Claude 共通

この区別を「私 = Claude」しか知らないと、別の Claude セッションや別の contributor が **ユーザーの個人的な好みを CLAUDE.md に commit してしまう** ような事故が起こりうる (= shared repo を一個人の taste で汚染する)。

今回のレビューでユーザー本人から「使い分けノウハウを repo にも記録しないと困らない?」と直接指摘されて気付いた。memory に書いただけだと、私の中では予防できても他の Claude には伝わらない。

## 変更

[CLAUDE.md](../blob/master/CLAUDE.md) に「Where to record what you learn (CLAUDE.md / docs vs Claude memory)」節を追加。

判断軸:

| カテゴリ | 行き先 |
|---|---|
| Repository facts (architecture, build flow, protocol matrix) | CLAUDE.md / docs |
| Coding conventions adopted by the project | CLAUDE.md / docs |
| Decision rationale that future maintainers will need | CLAUDE.md / docs |
| User preferences (返信言語、commit trailer 抑止) | Claude memory |
| Claude's own behavioral heuristics (subagent parallelization rules etc.) | Claude memory |
| "Last time I made mistake X" — Claude が自分用に残すリマインダ | Claude memory |

ルール: **「a new contributor cloning the repo would need this?」 → yes なら repo、no なら memory**。

## Test plan

\`.md\` の追加のみ。CI 動作に影響なし。