### PR TITLE
Phase 3: -Wreorder を潰して -Werror=reorder を有効化

### DIFF
--- a/cc/cicada/include/transaction.hh
+++ b/cc/cicada/include/transaction.hh
@@ -62,7 +62,7 @@ public:
   uint64_t gcstart_, gcstop_;            // for garbage collection
 
   TxExecutor(uint8_t thid, Backoff& backoff, Result *res, const bool &quit)
-    : result_(res), thid_(thid), backoff_(backoff), quit_(quit), callback_(TxScanCallback(this)) {
+    : result_(res), quit_(quit), callback_(TxScanCallback(this)), backoff_(backoff), thid_(thid) {
 
     // wait to initialize MinWts
     while (MinWts.load(memory_order_acquire) == 0);

--- a/cc/d2pl/include/transaction.hh
+++ b/cc/d2pl/include/transaction.hh
@@ -57,7 +57,7 @@ public:
   std::vector<LockEntry> lock_entries_;
 
   TxExecutor(int thid, Result *res,  const bool &quit)
-      : thid_(thid), result_(res), quit_(quit), backoff_(FLAGS_clocks_per_us) {
+      : thid_(thid), result_(res), backoff_(FLAGS_clocks_per_us), quit_(quit) {
     // read_set_.reserve(FLAGS_max_ope);
     // write_set_.reserve(FLAGS_max_ope);
     // pro_set_.reserve(FLAGS_max_ope);

--- a/cc/ermia/include/transaction.hh
+++ b/cc/ermia/include/transaction.hh
@@ -54,7 +54,7 @@ public:
   const bool& quit_; // for thread termination control
 
   TxExecutor(uint8_t thid, Backoff& backoff, Result *res, const bool &quit)
-    : result_(res), thid_(thid), backoff_(backoff), quit_(quit), callback_(TxScanCallback(this)) {
+    : thid_(thid), result_(res), callback_(TxScanCallback(this)), backoff_(backoff), quit_(quit) {
     gcobject_.set_thid_(thid);
 
     if (FLAGS_pre_reserve_tmt_element) {

--- a/cc/mocc/include/transaction.hh
+++ b/cc/mocc/include/transaction.hh
@@ -59,8 +59,8 @@ public:
   bool is_ronly_ = false;
 
   TxExecutor(int thid, Result *res, const bool &quit)
-    : result_(res), thid_(thid), quit_(quit), backoff_(FLAGS_clocks_per_us),
-      callback_(TxScanCallback(this)) {
+    : callback_(TxScanCallback(this)), thid_(thid), result_(res),
+      backoff_(FLAGS_clocks_per_us), quit_(quit) {
     this->status_ = TransactionStatus::inflight;
     this->rnd_.init();
     max_rset_.obj_ = 0;

--- a/cc/mvto/include/transaction.hh
+++ b/cc/mvto/include/transaction.hh
@@ -55,7 +55,7 @@ public:
   uint64_t gcstart_, gcstop_;            // for garbage collection
 
   TxExecutor(uint8_t thid, Backoff& backoff, Result *res, const bool &quit)
-    : result_(res), thid_(thid), backoff_(backoff), quit_(quit) {
+    : result_(res), quit_(quit), backoff_(backoff), thid_(thid) {
 
     // wait to initialize MinWts
     while (MinWts.load(memory_order_acquire) == 0);

--- a/cc/oze/include/oze.hh
+++ b/cc/oze/include/oze.hh
@@ -39,13 +39,13 @@ class TxNode {
         TxSet from_;       // incoming edges
         TxNode(TxID id) :
             id_(id),
-            is_aborted(false),
-            status_(TransactionStatus::inflight)
+            status_(TransactionStatus::inflight),
+            is_aborted(false)
             {};
         TxNode(TxID id, TransactionStatus status) :
             id_(id),
-            is_aborted(false),
-            status_(status)
+            status_(status),
+            is_aborted(false)
             {};
 };
 

--- a/cc/oze/include/transaction.hh
+++ b/cc/oze/include/transaction.hh
@@ -72,7 +72,7 @@ public:
     const bool& quit_; // for thread termination control
 
     TxExecutor(uint8_t thid, Backoff& backoff, Result *res, const bool &quit)
-        : result_(res), thid_(thid), backoff_(backoff), quit_(quit), callback_(TxScanCallback(this)) {
+        : result_(res), backoff_(backoff), callback_(TxScanCallback(this)), thid_(thid), quit_(quit) {
         txid_.thid = thid_;
         txid_.tid = 0;
 

--- a/cc/si/include/transaction.hh
+++ b/cc/si/include/transaction.hh
@@ -54,7 +54,7 @@ public:
   const bool& quit_; // for thread termination control
 
   TxExecutor(uint8_t thid, Backoff& backoff, Result *res, const bool &quit)
-    : result_(res), thid_(thid), backoff_(backoff), quit_(quit), callback_(TxScanCallback(this)) {
+    : thid_(thid), result_(res), callback_(TxScanCallback(this)), backoff_(backoff), quit_(quit) {
     gcobject_.set_thid_(thid);
 
     if (FLAGS_pre_reserve_tmt_element) {

--- a/cc/silo/include/transaction.hh
+++ b/cc/silo/include/transaction.hh
@@ -66,7 +66,7 @@ public:
   // char return_val_[VAL_SIZE];
 
   TxExecutor(int thid, Result *res, const bool &quit)
-    : result_(res), thid_(thid), quit_(quit), backoff_(FLAGS_clocks_per_us),
+    : thid_(thid), result_(res), backoff_(FLAGS_clocks_per_us), quit_(quit),
       callback_(TxScanCallback(this)) {
     // latest_log_header_.init();
     max_rset_.obj_ = 0;

--- a/cc/ss2pl/include/transaction.hh
+++ b/cc/ss2pl/include/transaction.hh
@@ -43,7 +43,7 @@ public:
   bool is_batch_ = false;
 
   TxExecutor(int thid, Result *res,  const bool &quit)
-    : thid_(thid), result_(res), quit_(quit), backoff_(FLAGS_clocks_per_us) {
+    : thid_(thid), result_(res), backoff_(FLAGS_clocks_per_us), quit_(quit) {
 //    read_set_.reserve(FLAGS_max_ope);
 //    write_set_.reserve(FLAGS_max_ope);
 //    pro_set_.reserve(FLAGS_max_ope);

--- a/cc/tictoc/include/transaction.hh
+++ b/cc/tictoc/include/transaction.hh
@@ -55,7 +55,7 @@ public:
   TxScanCallback callback_;
 
   TxExecutor(int thid, Result *res, const bool &quit)
-      : result_(res), thid_(thid), quit_(quit), backoff_(FLAGS_clocks_per_us),
+      : thid_(thid), result_(res), backoff_(FLAGS_clocks_per_us), quit_(quit),
         callback_(TxScanCallback(this)) {
     epoch_timer_start = rdtsc();
     epoch_timer_stop = 0;

--- a/cmake/ProtocolHelpers.cmake
+++ b/cmake/ProtocolHelpers.cmake
@@ -50,7 +50,8 @@ function(ccbench_add_protocol name)
     target_compile_options(${target} PRIVATE
       -Werror=maybe-uninitialized
       -Werror=unused-but-set-variable
-      -Werror=unused-label)
+      -Werror=unused-label
+      -Werror=reorder)
 
     set_property(TARGET ${target} PROPERTY CCBENCH_PROTOCOL "${name}")
     set_property(TARGET ${target} PROPERTY CCBENCH_WORKLOAD "${wl}")


### PR DESCRIPTION
[#43](https://github.com/thawk105/ccbench/issues/43) Phase 3 のサブタスク。`-Wreorder` (20 件ユニーク) を潰し、`ccbench_add_protocol()` に `-Werror=reorder` を追加する。

## 修正概要

すべて TxExecutor (10 protocols) と TxNode (oze) のコンストラクタで member initializer list の順序がクラス内のメンバ宣言順と一致していなかったケース。C++ の初期化は宣言順で行われるので、initializer list の順は無視される。「見た目の順に初期化されている」と読み手が思い込むのを防ぐため、宣言順に並べ替え。

各箇所でメンバ初期化式に副作用が無いことを確認 (純粋なリファレンス bind / コピー / `TxScanCallback(this)` のような前提のない式) してから順序のみを変更。挙動の変化は無し。

### 修正ファイル

| 箇所 | クラス |
|---|---|
| `cc/cicada/include/transaction.hh:65` | `TxExecutor` |
| `cc/d2pl/include/transaction.hh:60` | `TxExecutor` |
| `cc/ermia/include/transaction.hh:57` | `TxExecutor` |
| `cc/mocc/include/transaction.hh:62-63` | `TxExecutor` (`callback_` が先頭宣言) |
| `cc/mvto/include/transaction.hh:58` | `TxExecutor` |
| `cc/oze/include/oze.hh:40-49` | `TxNode` (2 コンストラクタ) |
| `cc/oze/include/transaction.hh:75` | `TxExecutor` |
| `cc/si/include/transaction.hh:57` | `TxExecutor` |
| `cc/silo/include/transaction.hh:69` | `TxExecutor` |
| `cc/ss2pl/include/transaction.hh:46` | `TxExecutor` |
| `cc/tictoc/include/transaction.hh:58` | `TxExecutor` |

### 真のバグ

無し。順序変更で挙動が変わるパターン (`Foo(int x) : a_(x++), b_(x)` のような副作用持ち) は混じっていなかった。

## CMake

```diff
 target_compile_options(${target} PRIVATE
   -Werror=maybe-uninitialized
   -Werror=unused-but-set-variable
-  -Werror=unused-label)
+  -Werror=unused-label
+  -Werror=reorder)
```

## Test plan

- [x] **GCC 13** Release / `-DENABLE_SANITIZER=OFF`: 34/34
- [x] **GCC 11** Debug + ASan: 34/34
- [ ] CI 緑

## Related

- #43 Phase 3 (parallel work)
- #50 (Phase 1 完了)