### PR TITLE
Phase 4: -Wunused-parameter を潰して -Werror=unused-parameter を有効化

### DIFF
--- a/cc/cicada/include/scan_callback.hh
+++ b/cc/cicada/include/scan_callback.hh
@@ -10,7 +10,9 @@ class TxScanCallback : public MasstreeWrapper<Tuple>::ScanCallback {
 
   void on_resp_node(const MasstreeWrapper<Tuple>::node_type *n, uint64_t version);
 
-  bool invoke(const std::string_view &k, Tuple v, const MasstreeWrapper<Tuple>::node_type *n, uint64_t version) {
+  bool invoke(const std::string_view & /*k*/, Tuple /*v*/,
+              const MasstreeWrapper<Tuple>::node_type * /*n*/,
+              uint64_t /*version*/) {
     return true;
   }
 };

--- a/cc/cicada/include/tuple.hh
+++ b/cc/cicada/include/tuple.hh
@@ -91,7 +91,8 @@ public:
 #endif
   }
 
-  void init(size_t thid, Version* ver, uint64_t initial_wts, TupleBody&& body) {
+  void init([[maybe_unused]] size_t thid, Version* ver, uint64_t initial_wts,
+            [[maybe_unused]] TupleBody&& body) {
     min_wts_ = initial_wts;
     gc_lock_.store(0, std::memory_order_release);
     continuing_commit_.store(0, std::memory_order_release);

--- a/cc/ermia/include/scan_callback.hh
+++ b/cc/ermia/include/scan_callback.hh
@@ -10,7 +10,9 @@ class TxScanCallback : public MasstreeWrapper<Tuple>::ScanCallback {
 
   void on_resp_node(const MasstreeWrapper<Tuple>::node_type *n, uint64_t version);
 
-  bool invoke(const std::string_view &k, Tuple v, const MasstreeWrapper<Tuple>::node_type *n, uint64_t version) {
+  bool invoke(const std::string_view & /*k*/, Tuple /*v*/,
+              const MasstreeWrapper<Tuple>::node_type * /*n*/,
+              uint64_t /*version*/) {
     return true;
   }
 };

--- a/cc/ermia/include/tuple.hh
+++ b/cc/ermia/include/tuple.hh
@@ -18,7 +18,7 @@ public:
     gc_lock_.store(0, std::memory_order_release);
   }
 
-  void init([[maybe_unused]] size_t thid, TupleBody&& body, void* param) {
+  void init([[maybe_unused]] size_t thid, TupleBody&& body, [[maybe_unused]] void* param) {
     // for initializer
     min_cstamp_ = 0;
     latest_.store(new Version(), std::memory_order_release);

--- a/cc/mocc/include/scan_callback.hh
+++ b/cc/mocc/include/scan_callback.hh
@@ -10,7 +10,9 @@ class TxScanCallback : public MasstreeWrapper<Tuple>::ScanCallback {
 
   void on_resp_node(const MasstreeWrapper<Tuple>::node_type *n, uint64_t version);
 
-  bool invoke(const std::string_view &k, Tuple v, const MasstreeWrapper<Tuple>::node_type *n, uint64_t version) {
+  bool invoke(const std::string_view & /*k*/, Tuple /*v*/,
+              const MasstreeWrapper<Tuple>::node_type * /*n*/,
+              uint64_t /*version*/) {
     return true;
   }
 };

--- a/cc/mvto/include/tuple.hh
+++ b/cc/mvto/include/tuple.hh
@@ -58,7 +58,8 @@ public:
     body_ = std::ref((latest_.load(std::memory_order_acquire))->body_);
   }
 
-  void init(size_t thid, Version* ver, uint64_t initial_wts, TupleBody&& body) {
+  void init([[maybe_unused]] size_t thid, Version* ver, uint64_t initial_wts,
+            [[maybe_unused]] TupleBody&& body) {
     min_wts_ = initial_wts;
     gc_lock_.store(0, std::memory_order_release);
     latest_.store(ver, std::memory_order_release);

--- a/cc/oze/include/scan_callback.hh
+++ b/cc/oze/include/scan_callback.hh
@@ -10,7 +10,9 @@ class TxScanCallback : public MasstreeWrapper<Tuple>::ScanCallback {
 
   void on_resp_node(const MasstreeWrapper<Tuple>::node_type *n, uint64_t version);
 
-  bool invoke(const std::string_view &k, Tuple v, const MasstreeWrapper<Tuple>::node_type *n, uint64_t version) {
+  bool invoke(const std::string_view & /*k*/, Tuple /*v*/,
+              const MasstreeWrapper<Tuple>::node_type * /*n*/,
+              uint64_t /*version*/) {
     return true;
   }
 };

--- a/cc/oze/include/tuple.hh
+++ b/cc/oze/include/tuple.hh
@@ -63,7 +63,7 @@ public:
   }
 
   // only for initial data preparation
-  void init([[maybe_unused]] size_t thid, TupleBody&& body, void* param) {
+  void init([[maybe_unused]] size_t thid, TupleBody&& body, [[maybe_unused]] void* param) {
 
     TxID txid = TxID();
     txid.thid = thid;

--- a/cc/oze/transaction.cc
+++ b/cc/oze/transaction.cc
@@ -470,7 +470,7 @@ Status TxExecutor::scan(const Storage s,
   return Status::OK;
 }
 
-void TxExecutor::validation_worker(size_t worker_id,
+void TxExecutor::validation_worker([[maybe_unused]] size_t worker_id,
     KeySet &target_set, size_t offset, size_t assignment,
     KeySet &propagate_set, Graph &graph, TransactionStatus &result) {
     // copy initial state

--- a/cc/si/include/scan_callback.hh
+++ b/cc/si/include/scan_callback.hh
@@ -10,7 +10,9 @@ class TxScanCallback : public MasstreeWrapper<Tuple>::ScanCallback {
 
   void on_resp_node(const MasstreeWrapper<Tuple>::node_type *n, uint64_t version);
 
-  bool invoke(const std::string_view &k, Tuple v, const MasstreeWrapper<Tuple>::node_type *n, uint64_t version) {
+  bool invoke(const std::string_view & /*k*/, Tuple /*v*/,
+              const MasstreeWrapper<Tuple>::node_type * /*n*/,
+              uint64_t /*version*/) {
     return true;
   }
 };

--- a/cc/si/include/tuple.hh
+++ b/cc/si/include/tuple.hh
@@ -18,7 +18,7 @@ public:
     gc_lock_.store(0, std::memory_order_release);
   }
 
-  void init([[maybe_unused]] size_t thid, TupleBody&& body, void* param) {
+  void init([[maybe_unused]] size_t thid, TupleBody&& body, [[maybe_unused]] void* param) {
     // for initializer
     min_cstamp_ = 0;
     latest_.store(new Version(), std::memory_order_release);

--- a/cc/silo/include/scan_callback.hh
+++ b/cc/silo/include/scan_callback.hh
@@ -10,7 +10,9 @@ class TxScanCallback : public MasstreeWrapper<Tuple>::ScanCallback {
 
   void on_resp_node(const MasstreeWrapper<Tuple>::node_type *n, uint64_t version);
 
-  bool invoke(const std::string_view &k, Tuple v, const MasstreeWrapper<Tuple>::node_type *n, uint64_t version) {
+  bool invoke(const std::string_view & /*k*/, Tuple /*v*/,
+              const MasstreeWrapper<Tuple>::node_type * /*n*/,
+              uint64_t /*version*/) {
     return true;
   }
 };

--- a/cc/ss2pl/util.cc
+++ b/cc/ss2pl/util.cc
@@ -54,7 +54,9 @@ void displayParameter() {
   cout << "#FLAGS_zipf_skew:\t" << FLAGS_zipf_skew << endl;
 }
 
-void partTableInit([[maybe_unused]] size_t thid, uint64_t start, uint64_t end) {}
+void partTableInit([[maybe_unused]] size_t thid,
+                   [[maybe_unused]] uint64_t start,
+                   [[maybe_unused]] uint64_t end) {}
 
 void makeDB() {}
 

--- a/cc/tictoc/include/scan_callback.hh
+++ b/cc/tictoc/include/scan_callback.hh
@@ -10,7 +10,9 @@ class TxScanCallback : public MasstreeWrapper<Tuple>::ScanCallback {
 
   void on_resp_node(const MasstreeWrapper<Tuple>::node_type *n, uint64_t version);
 
-  bool invoke(const std::string_view &k, Tuple v, const MasstreeWrapper<Tuple>::node_type *n, uint64_t version) {
+  bool invoke(const std::string_view & /*k*/, Tuple /*v*/,
+              const MasstreeWrapper<Tuple>::node_type * /*n*/,
+              uint64_t /*version*/) {
     return true;
   }
 };

--- a/cmake/ProtocolHelpers.cmake
+++ b/cmake/ProtocolHelpers.cmake
@@ -51,7 +51,8 @@ function(ccbench_add_protocol name)
       -Werror=maybe-uninitialized
       -Werror=unused-but-set-variable
       -Werror=unused-label
-      -Werror=reorder)
+      -Werror=reorder
+      -Werror=unused-parameter)
 
     set_property(TARGET ${target} PROPERTY CCBENCH_PROTOCOL "${name}")
     set_property(TARGET ${target} PROPERTY CCBENCH_WORKLOAD "${wl}")

--- a/include/bomb.hh
+++ b/include/bomb.hh
@@ -437,7 +437,7 @@ public:
       TxType type;
       TxArgs args;
 
-      TxType decideType(TxExecutor& tx, Xoroshiro128Plus& r) {
+      TxType decideType(TxExecutor& tx, [[maybe_unused]] Xoroshiro128Plus& r) {
         TxType txType;
         if (tx.thid_ < FLAGS_bomb_l1_thread_num) {
           txType = TxType::UpdateProductCostMaster;
@@ -1392,7 +1392,7 @@ RETRY:
       return TxType::ChangeProductQuantity;
     }
 
-    static void request_dispatcher(size_t thid, char &ready, const bool &start, const bool &quit) {
+    static void request_dispatcher([[maybe_unused]] size_t thid, char &ready, const bool &start, const bool &quit) {
       // prepare queues for short transactions
       int numQueues = TotalThreadNum - FLAGS_bomb_l1_thread_num;
       requestQueues = new ConcurrentQueue<std::pair<TxType, timepoint>>[numQueues];

--- a/include/bomb_pessimistic.hh
+++ b/include/bomb_pessimistic.hh
@@ -471,7 +471,7 @@ public:
       TxType type;
       TxArgs args;
 
-      TxType decideType(TxExecutor& tx, Xoroshiro128Plus& r) {
+      TxType decideType(TxExecutor& tx, [[maybe_unused]] Xoroshiro128Plus& r) {
         TxType txType;
         if (tx.thid_ < FLAGS_bomb_l1_thread_num) {
           txType = TxType::UpdateProductCostMaster;
@@ -1516,7 +1516,7 @@ RETRY:
       return TxType::ChangeProductQuantity;
     }
 
-    static void request_dispatcher(size_t thid, char &ready, const bool &start, const bool &quit) {
+    static void request_dispatcher([[maybe_unused]] size_t thid, char &ready, const bool &start, const bool &quit) {
       // prepare queues for short transactions
       int numQueues = TotalThreadNum - FLAGS_bomb_l1_thread_num;
       requestQueues = new ConcurrentQueue<std::pair<TxType, timepoint>>[numQueues];

--- a/include/masstree_wrapper.hh
+++ b/include/masstree_wrapper.hh
@@ -241,8 +241,9 @@ private:
 
 template<typename T>
 class MasstreeWrapper<T>::DefaultScanCallback : public ScanCallback {
-  void on_resp_node(const node_type *n, uint64_t version) {}
-  bool invoke(const std::string_view &k, T v, const node_type *n, uint64_t version) {
+  void on_resp_node(const node_type * /*n*/, uint64_t /*version*/) {}
+  bool invoke(const std::string_view & /*k*/, T /*v*/, const node_type * /*n*/,
+              uint64_t /*version*/) {
     return true;
   }
 };
@@ -267,8 +268,8 @@ class MasstreeWrapper<T>::SearchRangeScanner {
   }
 
   void visit_leaf(const Masstree::scanstackelt<table_params>& iter,
-                  const Masstree::key<uint64_t>& key,
-                  threadinfo& ti) {
+                  const Masstree::key<uint64_t>& /*key*/,
+                  threadinfo& /*ti*/) {
     const Masstree::leaf<table_params>* node = iter.node();
     uint64_t version = iter.full_version_value();
     callback_.on_resp_node(node, version);

--- a/include/tpcc.hh
+++ b/include/tpcc.hh
@@ -37,7 +37,7 @@ public:
       rnd_.init();
     }
 
-    void prepare(TxExecutor& tx, Param *p) {
+    void prepare(TxExecutor& tx, [[maybe_unused]] Param *p) {
       hkg_.init(tx.thid_, true);
       w_id = (tx.thid_ % FLAGS_tpcc_num_wh) + 1; // home warehouse.
     }

--- a/include/tpcc/tpcc_query.hh
+++ b/include/tpcc/tpcc_query.hh
@@ -237,7 +237,7 @@ public:
   std::uint8_t o_carrier_id;
   std::uint64_t ol_delivery_d;
 
-  void generate(uint16_t w_id0, Option &opt) {
+  void generate(uint16_t w_id0, [[maybe_unused]] Option &opt) {
 #ifdef FIXED_WAREHOUSE_PER_THREAD
     w_id = w_id0;
 #else


### PR DESCRIPTION
[#43](https://github.com/thawk105/ccbench/issues/43) Phase 4 のサブタスク。GCC 13 `-Wunused-parameter` で出ていた 120 件 (10 protocol 展開込み、ユニークなソース位置は 21 箇所) を潰し、`ccbench_add_protocol()` に `-Werror=unused-parameter` を追加する。

## 修正概要

スコープ過大化を避けるため API 形状は保ち、引数名隠しか `[[maybe_unused]]` 属性で対応。引数自体の削除はしていない。

| カテゴリ | 件数 | 主な対象 |
|---|---:|---|
| `[[maybe_unused]]` 属性 | 13 | `Delivery::generate` の `opt` (FIXED_WAREHOUSE_PER_THREAD 条件分岐)、`BoMB::Query::decideType` の Xoroshiro128Plus、`request_dispatcher` の `thid`、`TPCCWorkload::prepare` の `Param*`、ermia/si/oze の `Tuple::init` の `void* param`、cicada/mvto の `Tuple::init` の `thid` と `body`、oze の `validation_worker` の `worker_id` (#if DEBUG_MSG)、ss2pl/util.cc の空関数 `partTableInit` |
| 引数名隠し (`/*name*/`) | 8 | `include/masstree_wrapper.hh` の `DefaultScanCallback` と `SearchRangeScanner::visit_leaf` (Masstree インターフェース契約)、`cc/{cicada,ermia,mocc,oze,si,silo,tictoc}/include/scan_callback.hh` の `TxScanCallback::invoke` デフォルト実装 (7 ファイル各 4 引数) |

### 潜在バグ候補 (本 PR では触らない)

`cc/cicada/include/tuple.hh:94` と `cc/mvto/include/tuple.hh:61` の
`init(thid, ver, initial_wts, TupleBody&& body)` は `body` を受け取って捨てている。
対になっている overload `init(thid, body, param)` では `inline_ver_.body_` や
`latest_->body_` に `std::move` しているため、unused にしている方は意図的でない
可能性がある。scope を保つため本 PR では `[[maybe_unused]]` でマークするに
留めたが、別 PR で要レビュー。

## CMake

```diff
 target_compile_options(${target} PRIVATE
   -Werror=maybe-uninitialized
   -Werror=unused-but-set-variable
-  -Werror=unused-label)
+  -Werror=unused-label
+  -Werror=unused-parameter)
```

## Test plan

- [x] **GCC 13** Release / `-DENABLE_SANITIZER=OFF`: 34/34
- [x] **GCC 11** Debug + ASan: 34/34
- [ ] CI 緑

## Related

- #43 Phase 4 (parallel work)
- #50 (Phase 1 完了)