### PR TITLE
Phase 3: -Wcatch-value を潰して -Werror=catch-value を有効化

### DIFF
--- a/cc/cicada/bomb_cicada.cc
+++ b/cc/cicada/bomb_cicada.cc
@@ -111,6 +111,6 @@ int main(int argc, char *argv[]) try {
   // deleteDB();
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/cicada/sbomb_cicada.cc
+++ b/cc/cicada/sbomb_cicada.cc
@@ -106,6 +106,6 @@ int main(int argc, char *argv[]) try {
   // deleteDB();
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/cicada/tpcc_cicada.cc
+++ b/cc/cicada/tpcc_cicada.cc
@@ -106,6 +106,6 @@ int main(int argc, char *argv[]) try {
   // deleteDB();
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/cicada/ycsb_cicada.cc
+++ b/cc/cicada/ycsb_cicada.cc
@@ -100,6 +100,6 @@ int main(int argc, char *argv[]) try {
   // deleteDB();
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/d2pl/dbomb_d2pl.cc
+++ b/cc/d2pl/dbomb_d2pl.cc
@@ -107,6 +107,6 @@ int main(int argc, char *argv[]) try {
   D2PLResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/d2pl/sbomb_d2pl.cc
+++ b/cc/d2pl/sbomb_d2pl.cc
@@ -107,6 +107,6 @@ int main(int argc, char *argv[]) try {
   D2PLResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/ermia/bomb_ermia.cc
+++ b/cc/ermia/bomb_ermia.cc
@@ -108,6 +108,6 @@ int main(int argc, char *argv[]) try {
   ErmiaResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/ermia/sbomb_ermia.cc
+++ b/cc/ermia/sbomb_ermia.cc
@@ -103,6 +103,6 @@ int main(int argc, char *argv[]) try {
   ErmiaResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/ermia/tpcc_ermia.cc
+++ b/cc/ermia/tpcc_ermia.cc
@@ -103,6 +103,6 @@ int main(int argc, char *argv[]) try {
   ErmiaResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/ermia/util.cc
+++ b/cc/ermia/util.cc
@@ -59,7 +59,7 @@ void chkArg() {
   try {
     TMT = new TransactionTable *[TotalThreadNum];
     MinQueuedCstamp = new std::atomic<uint32_t>[TotalThreadNum];
-  } catch (bad_alloc) {
+  } catch (const bad_alloc&) {
     ERR;
   }
 

--- a/cc/ermia/ycsb_ermia.cc
+++ b/cc/ermia/ycsb_ermia.cc
@@ -100,6 +100,6 @@ int main(int argc, char *argv[]) try {
                                   FLAGS_max_ope, FLAGS_batch_max_ope);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/mocc/bomb_mocc.cc
+++ b/cc/mocc/bomb_mocc.cc
@@ -98,6 +98,6 @@ int main(int argc, char *argv[]) try {
   MoccResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/mocc/sbomb_mocc.cc
+++ b/cc/mocc/sbomb_mocc.cc
@@ -93,6 +93,6 @@ int main(int argc, char *argv[]) try {
   MoccResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/mocc/tpcc_mocc.cc
+++ b/cc/mocc/tpcc_mocc.cc
@@ -93,6 +93,6 @@ int main(int argc, char *argv[]) try {
   MoccResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/mocc/ycsb_mocc.cc
+++ b/cc/mocc/ycsb_mocc.cc
@@ -89,6 +89,6 @@ int main(int argc, char *argv[]) try {
   MoccResult[0].displayAllResult(FLAGS_clocks_per_us, FLAGS_extime, TotalThreadNum);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/mvto/bomb_mvto.cc
+++ b/cc/mvto/bomb_mvto.cc
@@ -100,6 +100,6 @@ int main(int argc, char *argv[]) try {
   MvtoResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/mvto/tpcc_mvto.cc
+++ b/cc/mvto/tpcc_mvto.cc
@@ -92,6 +92,6 @@ int main(int argc, char *argv[]) try {
   MvtoResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/oze/bomb_oze.cc
+++ b/cc/oze/bomb_oze.cc
@@ -117,6 +117,6 @@ int main(int argc, char *argv[]) try {
   OzeResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/oze/tpcc_oze.cc
+++ b/cc/oze/tpcc_oze.cc
@@ -113,6 +113,6 @@ int main(int argc, char *argv[]) try {
   OzeResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/oze/util.cc
+++ b/cc/oze/util.cc
@@ -34,7 +34,7 @@ void init(int32_t table_num) {
   // init
   try {
     ThManagementTable = new ThreadManagementEntry *[TotalThreadNum];
-  } catch (bad_alloc) {
+  } catch (const bad_alloc&) {
     ERR;
   }
   for (unsigned int i = 0; i < TotalThreadNum; ++i) {

--- a/cc/oze/ycsb_oze.cc
+++ b/cc/oze/ycsb_oze.cc
@@ -104,6 +104,6 @@ int main(int argc, char *argv[]) try {
   OzeResult[0].displayAllResult(FLAGS_clocks_per_us, FLAGS_extime, TotalThreadNum);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/si/bomb_si.cc
+++ b/cc/si/bomb_si.cc
@@ -108,6 +108,6 @@ int main(int argc, char *argv[]) try {
   SIResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/si/sbomb_si.cc
+++ b/cc/si/sbomb_si.cc
@@ -103,6 +103,6 @@ int main(int argc, char *argv[]) try {
   SIResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/si/tpcc_si.cc
+++ b/cc/si/tpcc_si.cc
@@ -103,6 +103,6 @@ int main(int argc, char *argv[]) try {
   SIResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/si/util.cc
+++ b/cc/si/util.cc
@@ -59,7 +59,7 @@ void chkArg() {
   try {
     TMT = new TransactionTable *[TotalThreadNum];
     MinQueuedCstamp = new std::atomic<uint32_t>[TotalThreadNum];
-  } catch (bad_alloc) {
+  } catch (const bad_alloc&) {
     ERR;
   }
 

--- a/cc/si/ycsb_si.cc
+++ b/cc/si/ycsb_si.cc
@@ -100,6 +100,6 @@ int main(int argc, char *argv[]) try {
                                   FLAGS_max_ope, FLAGS_batch_max_ope);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/silo/bomb_silo.cc
+++ b/cc/silo/bomb_silo.cc
@@ -127,6 +127,6 @@ int main(int argc, char *argv[]) try {
   SiloResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/silo/sbomb_silo.cc
+++ b/cc/silo/sbomb_silo.cc
@@ -122,6 +122,6 @@ int main(int argc, char *argv[]) try {
   SiloResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/silo/tpcc_silo.cc
+++ b/cc/silo/tpcc_silo.cc
@@ -122,6 +122,6 @@ int main(int argc, char *argv[]) try {
   SiloResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/silo/ycsb_silo.cc
+++ b/cc/silo/ycsb_silo.cc
@@ -118,6 +118,6 @@ int main(int argc, char *argv[]) try {
   SiloResult[0].displayAllResult(FLAGS_clocks_per_us, FLAGS_extime, TotalThreadNum);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/ss2pl/bomb_ss2pl.cc
+++ b/cc/ss2pl/bomb_ss2pl.cc
@@ -115,6 +115,6 @@ int main(int argc, char *argv[]) try {
   SS2PLResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/ss2pl/tpcc_ss2pl.cc
+++ b/cc/ss2pl/tpcc_ss2pl.cc
@@ -96,6 +96,6 @@ int main(int argc, char *argv[]) try {
   SS2PLResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/tictoc/bomb_tictoc.cc
+++ b/cc/tictoc/bomb_tictoc.cc
@@ -103,6 +103,6 @@ int main(int argc, char *argv[]) try {
   TicTocResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/tictoc/sbomb_tictoc.cc
+++ b/cc/tictoc/sbomb_tictoc.cc
@@ -98,6 +98,6 @@ int main(int argc, char *argv[]) try {
   TicTocResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/tictoc/tpcc_tictoc.cc
+++ b/cc/tictoc/tpcc_tictoc.cc
@@ -98,6 +98,6 @@ int main(int argc, char *argv[]) try {
   TicTocResult[0].displayPerTxResult(TxTypes);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cc/tictoc/ycsb_tictoc.cc
+++ b/cc/tictoc/ycsb_tictoc.cc
@@ -94,6 +94,6 @@ int main(int argc, char *argv[]) try {
                                    FLAGS_thread_num);
 
   return 0;
-} catch (bad_alloc) {
+} catch (const bad_alloc&) {
   ERR;
 }

--- a/cmake/ProtocolHelpers.cmake
+++ b/cmake/ProtocolHelpers.cmake
@@ -52,7 +52,8 @@ function(ccbench_add_protocol name)
       -Werror=unused-but-set-variable
       -Werror=unused-label
       -Werror=reorder
-      -Werror=unused-parameter)
+      -Werror=unused-parameter
+      -Werror=catch-value)
 
     set_property(TARGET ${target} PROPERTY CCBENCH_PROTOCOL "${name}")
     set_property(TARGET ${target} PROPERTY CCBENCH_WORKLOAD "${wl}")

--- a/include/bomb.hh
+++ b/include/bomb.hh
@@ -477,7 +477,7 @@ public:
             try {
               ret = requestQueues[queueIndex].pop();
               break;
-            } catch (std::out_of_range e) {
+            } catch (const std::out_of_range& e) {
               std::this_thread::sleep_for(std::chrono::nanoseconds(100));
             }
           }

--- a/include/bomb_pessimistic.hh
+++ b/include/bomb_pessimistic.hh
@@ -511,7 +511,7 @@ public:
             try {
               ret = requestQueues[queueIndex].pop();
               break;
-            } catch (std::out_of_range e) {
+            } catch (const std::out_of_range& e) {
               std::this_thread::sleep_for(std::chrono::nanoseconds(100));
             }
           }


### PR DESCRIPTION
[#43](https://github.com/thawk105/ccbench/issues/43) Phase 3 のサブタスク。`-Wcatch-value` の 46 件 (ユニーク) を潰し、`ccbench_add_protocol()` に `-Werror=catch-value` を追加する。

すべて「polymorphic 例外型を value で catch している」典型ケース。スライシングを防ぐため `const T&` に統一した。Phase 1 のような真のバグは含まれていない。

## 修正パターン

| パターン | Before | After | 件数 |
|---|---|---|---|
| A | `} catch (bad_alloc) {` | `} catch (const bad_alloc&) {` | 44 |
| B | `} catch (std::out_of_range e) {` | `} catch (const std::out_of_range& e) {` | 2 |

B はヘッダ 2 か所のみだが、`BombWorkload::Query::getRequest` のテンプレ展開で 10 protocols × bomb 系 = 11 件にカウントされていた。

## 修正ファイル

`main()` の `bad_alloc` (各 `.exe` ソース計 34 件) + `util.cc` の初期化 `bad_alloc` (3 件) + `include/bomb.hh:480` + `include/bomb_pessimistic.hh:514`。合計 39 ファイル。

build に出ていない legacy ファイル (`cc/{cicada,ermia,mocc,…}.cc`, `cc/occ/occ.cc`) にも同パターンが残っているが、これらは `ccbench_add_protocol()` の SOURCES に未登録で CMake target がないためスコープ外。

## CMake

```diff
 target_compile_options(${target} PRIVATE
   -Werror=maybe-uninitialized
   -Werror=unused-but-set-variable
-  -Werror=unused-label)
+  -Werror=unused-label
+  -Werror=catch-value)
```

## Test plan

- [x] **GCC 13** / Release / `-DENABLE_SANITIZER=OFF`: 34/34 `.exe`、catch-value 0
- [x] **GCC 11** / Debug+ASan (devcontainer default): 34/34 `.exe`、catch-value 0
- [ ] CI 緑

## Related

- #43 Phase 3 (parallel work)
- #50 (Phase 1 完了)