### PR TITLE
Phase 4: -Wunused-variable を潰して -Werror=unused-variable を有効化

### DIFF
--- a/cc/cicada/bomb_cicada.cc
+++ b/cc/cicada/bomb_cicada.cc
@@ -39,7 +39,6 @@ using namespace std;
 void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   Backoff backoff(FLAGS_clocks_per_us);
   TxExecutor trans(thid, backoff, (Result *) &CicadaResult[thid], quit);
-  Result &myres = std::ref(CicadaResult[thid]);
   BombWorkload<Tuple,TupleInitParam> workload;
   workload.prepare(trans, new TupleInitParam());
 

--- a/cc/cicada/sbomb_cicada.cc
+++ b/cc/cicada/sbomb_cicada.cc
@@ -39,7 +39,6 @@ using namespace std;
 void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   Backoff backoff(FLAGS_clocks_per_us);
   TxExecutor trans(thid, backoff, (Result *) &CicadaResult[thid], quit);
-  Result &myres = std::ref(CicadaResult[thid]);
   StaticBombWorkload<Tuple,TupleInitParam> workload;
   workload.prepare(trans, new TupleInitParam());
 

--- a/cc/cicada/tpcc_cicada.cc
+++ b/cc/cicada/tpcc_cicada.cc
@@ -39,7 +39,6 @@ using namespace std;
 void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   Backoff backoff(FLAGS_clocks_per_us);
   TxExecutor trans(thid, backoff, (Result *) &CicadaResult[thid], quit);
-  Result &myres = std::ref(CicadaResult[thid]);
   TPCCWorkload<Tuple,TupleInitParam> workload;
   workload.prepare(trans, new TupleInitParam());
 

--- a/cc/cicada/transaction.cc
+++ b/cc/cicada/transaction.cc
@@ -446,7 +446,10 @@ Status TxExecutor::scan(const Storage s,
       continue;
     }
 
-    Version* v = read_internal(s, key, itr);
+    // read_internal pushes the visible version into read_set_ on success;
+    // the caller appends from read_set_ at the bottom of scan(). The return
+    // value is only useful for in-place reads, which scan() does not need.
+    (void)read_internal(s, key, itr);
     if (this->status_ == TransactionStatus::aborted)
       return Status::ERROR_PREEMPTIVE_ABORT;
   }

--- a/cc/cicada/ycsb_cicada.cc
+++ b/cc/cicada/ycsb_cicada.cc
@@ -40,7 +40,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   YcsbWorkload workload;
   Backoff backoff(FLAGS_clocks_per_us);
   TxExecutor trans(thid, backoff, (Result *) &CicadaResult[thid], quit);
-  Result &myres = std::ref(CicadaResult[thid]);
 
 #ifdef Linux
   setThreadAffinity(thid);

--- a/cc/d2pl/transaction.cc
+++ b/cc/d2pl/transaction.cc
@@ -83,7 +83,9 @@ bool TxExecutor::commit() {
         break;
       }
       case OpType::DELETE: {
-        Status stat = Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);       
+        // Return value intentionally ignored: a missing key still needs the
+        // record put on the GC queue below.
+        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
         // create information for garbage collection
         gc_records_.push_back((*itr).rcdptr_);
         break;

--- a/cc/ermia/bomb_ermia.cc
+++ b/cc/ermia/bomb_ermia.cc
@@ -40,7 +40,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
 
   Backoff backoff(FLAGS_clocks_per_us); // Cicada's backoff opt.
   TxExecutor trans(thid, backoff, (Result *) &ErmiaResult[thid], quit);
-  Result &myres = std::ref(ErmiaResult[thid]);
   BombWorkload<Tuple,void> workload;
 
 #ifdef Linux

--- a/cc/ermia/sbomb_ermia.cc
+++ b/cc/ermia/sbomb_ermia.cc
@@ -40,7 +40,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
 
   Backoff backoff(FLAGS_clocks_per_us); // Cicada's backoff opt.
   TxExecutor trans(thid, backoff, (Result *) &ErmiaResult[thid], quit);
-  Result &myres = std::ref(ErmiaResult[thid]);
   StaticBombWorkload<Tuple,void> workload;
 
 #ifdef Linux

--- a/cc/ermia/tpcc_ermia.cc
+++ b/cc/ermia/tpcc_ermia.cc
@@ -40,7 +40,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
 
   Backoff backoff(FLAGS_clocks_per_us); // Cicada's backoff opt.
   TxExecutor trans(thid, backoff, (Result *) &ErmiaResult[thid], quit);
-  Result &myres = std::ref(ErmiaResult[thid]);
   TPCCWorkload<Tuple,void> workload;
 
 #ifdef Linux

--- a/cc/ermia/transaction.cc
+++ b/cc/ermia/transaction.cc
@@ -387,7 +387,6 @@ Status TxExecutor::delete_record(Storage s, std::string_view key) {
   }
 
   Tuple* tuple = nullptr;
-  SetElement<Tuple> *re;
   for (auto itr = read_set_.begin(); itr != read_set_.end(); ++itr) {
     if ((*itr).storage_ == s && (*itr).key_ == key) {
       downReadersBits((*itr).ver_);
@@ -405,7 +404,7 @@ Status TxExecutor::delete_record(Storage s, std::string_view key) {
     if (tuple == nullptr) return Status::WARN_NOT_FOUND;
   }
 
-  Version *expected, *desired;
+  Version *desired;
   desired = new Version();
   if (gcobject_.reuse_version_from_gc_.empty()) {
     desired = new Version();

--- a/cc/ermia/ycsb_ermia.cc
+++ b/cc/ermia/ycsb_ermia.cc
@@ -37,7 +37,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   Backoff backoff(FLAGS_clocks_per_us); // Cicada's backoff opt.
   TxExecutor trans(thid, backoff, (Result *) &ErmiaResult[thid], quit);
   YcsbWorkload workload;
-  Result &myres = std::ref(ErmiaResult[thid]);
 
 #if MASSTREE_USE
   MasstreeWrapper<Tuple>::thread_init(int(thid));

--- a/cc/mocc/transaction.cc
+++ b/cc/mocc/transaction.cc
@@ -1045,7 +1045,9 @@ void TxExecutor::writePhase() {
       }
       case OpType::DELETE: {
         maxtid.absent = true;
-        Status stat = Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
+        // Return value intentionally ignored: a missing key still needs the
+        // record put on the GC queue below.
+        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
         gc_records_.push_back((*itr).rcdptr_);
         break;
       }

--- a/cc/mvto/bomb_mvto.cc
+++ b/cc/mvto/bomb_mvto.cc
@@ -30,7 +30,6 @@ using namespace std;
 void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   Backoff backoff(FLAGS_clocks_per_us);
   TxExecutor trans(thid, backoff, (Result *) &MvtoResult[thid], quit);
-  Result &myres = std::ref(MvtoResult[thid]);
   BombWorkload<Tuple,TupleInitParam> workload;
   workload.prepare(trans, new TupleInitParam());
 

--- a/cc/mvto/tpcc_mvto.cc
+++ b/cc/mvto/tpcc_mvto.cc
@@ -30,7 +30,6 @@ using namespace std;
 void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   Backoff backoff(FLAGS_clocks_per_us);
   TxExecutor trans(thid, backoff, (Result *) &MvtoResult[thid], quit);
-  Result &myres = std::ref(MvtoResult[thid]);
   TPCCWorkload<Tuple,TupleInitParam> workload;
   workload.prepare(trans, new TupleInitParam());
 

--- a/cc/mvto/transaction.cc
+++ b/cc/mvto/transaction.cc
@@ -137,7 +137,7 @@ Status TxExecutor::update(Storage s, std::string_view key, TupleBody &&body) {
   }
 
   // Install new version with pending state
-  Version *ver, *new_ver;
+  Version *new_ver;
   new_ver = newVersionGeneration(tuple, std::move(body));
   if (FLAGS_preserve_write) {
     install_version(tuple, new_ver);
@@ -213,7 +213,7 @@ Status TxExecutor::delete_record(Storage s, std::string_view key) {
   }
 
   // Install delete version with pending state
-  Version *ver, *new_ver;
+  Version *new_ver;
   new_ver = new Version(this->wts_.ts_);
   if (FLAGS_preserve_write) {
     install_version(tuple, new_ver);
@@ -263,7 +263,10 @@ Status TxExecutor::scan(const Storage s,
       continue;
     }
 
-    Version *v = read_internal(s, key, itr);
+    // read_internal pushes the visible version into read_set_ on success;
+    // the caller appends from read_set_ at the bottom of scan(). The return
+    // value is only useful for in-place reads, which scan() does not need.
+    (void)read_internal(s, key, itr);
     if (this->status_ == TransactionStatus::aborted)
       return Status::ERROR_PREEMPTIVE_ABORT;
   }

--- a/cc/oze/bomb_oze.cc
+++ b/cc/oze/bomb_oze.cc
@@ -39,8 +39,6 @@ using namespace std;
 void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   Backoff backoff(FLAGS_clocks_per_us);
   TxExecutor trans(thid, backoff, (Result *) &OzeResult[thid], quit);
-  Result &myres = std::ref(OzeResult[thid]);
-  uint64_t epoch_timer_start, epoch_timer_stop;
   BombWorkload<Tuple,void> workload;
   workload.prepare(trans, nullptr);
 
@@ -112,6 +110,7 @@ int main(int argc, char *argv[]) try {
     OzeResult[0].addLocalPerTxResult(OzeResult[i], TxTypes);
   }
   ShowOptParameters();
+  std::cout << "actual_extime:\t" << actual_extime << std::endl;
   OzeResult[0].displayAllResult(FLAGS_clocks_per_us, FLAGS_extime, TotalThreadNum);
   std::cout << "Details per transaction type:" << std::endl;
   OzeResult[0].displayPerTxResult(TxTypes);

--- a/cc/oze/include/transaction.hh
+++ b/cc/oze/include/transaction.hh
@@ -489,7 +489,6 @@ public:
 
     Status __get_visible_version(Tuple *tuple, Version **return_ver, bool aligned_read=false) {
         Status stat = Status::OK;
-        bool isInvisible;
         Version* ver = nullptr;
         Version* prev_ver = nullptr;
         std::vector<Version*> followers;

--- a/cc/oze/tpcc_oze.cc
+++ b/cc/oze/tpcc_oze.cc
@@ -39,8 +39,6 @@ using namespace std;
 void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   Backoff backoff(FLAGS_clocks_per_us);
   TxExecutor trans(thid, backoff, (Result *) &OzeResult[thid], quit);
-  Result &myres = std::ref(OzeResult[thid]);
-  uint64_t epoch_timer_start, epoch_timer_stop;
   TPCCWorkload<Tuple,void> workload;
   workload.prepare(trans, nullptr);
 

--- a/cc/oze/transaction.cc
+++ b/cc/oze/transaction.cc
@@ -68,7 +68,6 @@ Status TxExecutor::read(Storage s, std::string_view key, TupleBody** body) {
 
     Status ret = Status::OK;
     TxID target;
-    bool isInvisible;
     Tuple *tuple;
     Version *ver = nullptr;
     ReadElement<Tuple>* re;
@@ -142,10 +141,7 @@ ABORT_READ:
 
 Status TxExecutor::read_internal(Storage s, std::string_view key, Tuple* tuple, Version** return_ver) {
     TxID target;
-    bool isInvisible;
     Version *ver = nullptr;
-    ReadElement<Tuple>* re;
-    WriteElement<Tuple>* we;
     Status stat = Status::OK;
 
     tuple->lock_.w_lock();
@@ -563,9 +559,6 @@ bool TxExecutor::validation() {
     uint64_t start = rdtscp();
 #endif  // if ADD_ANALYSIS
 
-    int num_pages = 0;
-    int num_skip_propagate = 0;
-
     KeySet finished_set;
     KeySet propagate_set;
 
@@ -806,7 +799,7 @@ bool TxExecutor::write_validation(WriteElement<Tuple> element, KeySet& finished_
     for (auto& txid : reachable_to) {
         add_related_read_keys(&tuple->graph_.at(txid), followers_read_keys);
     }
-    for (const auto& k : followers_read_keys) {
+    for ([[maybe_unused]] const auto& k : followers_read_keys) {
         push_candidate_keys(propagate_set, finished_set, followers_read_keys);
     }
 
@@ -920,8 +913,6 @@ bool TxExecutor::read_validation(KeySet& target_set, KeySet& finished_set) {
 #endif
 
     while (!target_set.empty()) {
-        ReadElement<Tuple> *re;
-        WriteElement<Tuple> *we;
         auto iterator = target_set.cbegin();
         Tuple* tuple = *iterator;
         std::string key(tuple->latest_.load(memory_order_acquire)->body_.get_key());
@@ -971,7 +962,7 @@ bool TxExecutor::read_validation(KeySet& target_set, KeySet& finished_set) {
         for (auto& txid : reachable_to) {
             add_related_read_keys(&tuple->graph_.at(txid), keys);
         }
-        for (const auto& k : keys) {
+        for ([[maybe_unused]] const auto& k : keys) {
             push_candidate_keys(target_set, finished_set, keys);
         }
 

--- a/cc/oze/ycsb_oze.cc
+++ b/cc/oze/ycsb_oze.cc
@@ -40,8 +40,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   YcsbWorkload workload;
   Backoff backoff(FLAGS_clocks_per_us);
   TxExecutor trans(thid, backoff, (Result *) &OzeResult[thid], quit);
-  Result &myres = std::ref(OzeResult[thid]);
-  uint64_t epoch_timer_start, epoch_timer_stop;
 
 #ifdef Linux
   setThreadAffinity(thid);
@@ -101,6 +99,7 @@ int main(int argc, char *argv[]) try {
     OzeResult[0].addLocalAllResult(OzeResult[i]);
   }
   ShowOptParameters();
+  std::cout << "actual_extime:\t" << actual_extime << std::endl;
   OzeResult[0].displayAllResult(FLAGS_clocks_per_us, FLAGS_extime, TotalThreadNum);
 
   return 0;

--- a/cc/si/bomb_si.cc
+++ b/cc/si/bomb_si.cc
@@ -40,7 +40,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
 
   Backoff backoff(FLAGS_clocks_per_us); // Cicada's backoff opt.
   TxExecutor trans(thid, backoff, (Result *) &SIResult[thid], quit);
-  Result &myres = std::ref(SIResult[thid]);
   BombWorkload<Tuple,void> workload;
 
 #ifdef Linux

--- a/cc/si/sbomb_si.cc
+++ b/cc/si/sbomb_si.cc
@@ -40,7 +40,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
 
   Backoff backoff(FLAGS_clocks_per_us); // Cicada's backoff opt.
   TxExecutor trans(thid, backoff, (Result *) &SIResult[thid], quit);
-  Result &myres = std::ref(SIResult[thid]);
   StaticBombWorkload<Tuple,void> workload;
 
 #ifdef Linux

--- a/cc/si/tpcc_si.cc
+++ b/cc/si/tpcc_si.cc
@@ -40,7 +40,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
 
   Backoff backoff(FLAGS_clocks_per_us); // Cicada's backoff opt.
   TxExecutor trans(thid, backoff, (Result *) &SIResult[thid], quit);
-  Result &myres = std::ref(SIResult[thid]);
   TPCCWorkload<Tuple,void> workload;
 
 #ifdef Linux

--- a/cc/si/transaction.cc
+++ b/cc/si/transaction.cc
@@ -361,7 +361,6 @@ Status TxExecutor::delete_record(Storage s, std::string_view key) {
   }
 
   Tuple* tuple = nullptr;
-  SetElement<Tuple> *re;
   for (auto itr = read_set_.begin(); itr != read_set_.end(); ++itr) {
     if ((*itr).storage_ == s && (*itr).key_ == key) {
       downReadersBits((*itr).ver_);
@@ -379,7 +378,7 @@ Status TxExecutor::delete_record(Storage s, std::string_view key) {
     if (tuple == nullptr) return Status::WARN_NOT_FOUND;
   }
 
-  Version *expected, *desired;
+  Version *desired;
   desired = new Version();
   if (gcobject_.reuse_version_from_gc_.empty()) {
     desired = new Version();

--- a/cc/si/ycsb_si.cc
+++ b/cc/si/ycsb_si.cc
@@ -37,7 +37,6 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit) {
   Backoff backoff(FLAGS_clocks_per_us); // Cicada's backoff opt.
   TxExecutor trans(thid, backoff, (Result *) &SIResult[thid], quit);
   YcsbWorkload workload;
-  Result &myres = std::ref(SIResult[thid]);
 
 #if MASSTREE_USE
   MasstreeWrapper<Tuple>::thread_init(int(thid));

--- a/cc/silo/transaction.cc
+++ b/cc/silo/transaction.cc
@@ -552,7 +552,9 @@ void TxExecutor::writePhase() {
       }
       case OpType::DELETE: {
         maxtid.absent = true;
-        Status stat = Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
+        // Return value intentionally ignored: a missing key still needs the
+        // tid bump and gc_records_ push below.
+        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
         storeRelease((*itr).rcdptr_->tidword_.obj_, maxtid.obj_);
         // create information for garbage collection
         gc_records_.push_back((*itr).rcdptr_);

--- a/cc/ss2pl/transaction.cc
+++ b/cc/ss2pl/transaction.cc
@@ -83,7 +83,9 @@ bool TxExecutor::commit() {
         break;
       }
       case OpType::DELETE: {
-        Status stat = Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
+        // Return value intentionally ignored: a missing key still needs the
+        // record put on the GC queue below.
+        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
         // create information for garbage collection
         gc_records_.push_back((*itr).rcdptr_);
         break;

--- a/cc/tictoc/transaction.cc
+++ b/cc/tictoc/transaction.cc
@@ -524,7 +524,9 @@ void TxExecutor::writePhase() {
       }
       case OpType::DELETE: {
         result.absent = true;
-        Status stat = Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
+        // Return value intentionally ignored: a missing key still needs the
+        // record put on the GC queue below.
+        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
         gc_records_.emplace_back((*itr).storage_, (*itr).key_, (*itr).rcdptr_, ThLocalEpoch[thid_].obj_);
         break;
       }

--- a/cmake/ProtocolHelpers.cmake
+++ b/cmake/ProtocolHelpers.cmake
@@ -53,7 +53,8 @@ function(ccbench_add_protocol name)
       -Werror=unused-label
       -Werror=reorder
       -Werror=unused-parameter
-      -Werror=catch-value)
+      -Werror=catch-value
+      -Werror=unused-variable)
 
     set_property(TARGET ${target} PROPERTY CCBENCH_PROTOCOL "${name}")
     set_property(TARGET ${target} PROPERTY CCBENCH_WORKLOAD "${wl}")

--- a/include/bomb.hh
+++ b/include/bomb.hh
@@ -547,7 +547,9 @@ public:
       if (FLAGS_bomb_use_cache) {
         tx.reconnoiter_begin();
         std::vector<uint32_t> product_ids;
-        auto ret = BombWorkload<Tuple,Param>::select_im_by_factory(tx, 1, product_ids);
+        // Return value intentionally discarded: the reconnaissance pass
+        // populates product_ids, which is all we need here.
+        (void)BombWorkload<Tuple,Param>::select_im_by_factory(tx, 1, product_ids);
         for (auto& p_id : product_ids) {
           Node* root = BombWorkload<Tuple,Param>::build_bom_tree(tx, p_id);
           if (root == nullptr) ERR;
@@ -581,7 +583,6 @@ public:
       while (next.size() != 0) {
         auto node = next.back();
         next.pop_back();
-        auto n = tx.read_set_.size();
         ItemConstructionMaster::CreateKey(node->i_id_, 0, low.ptr());
         ItemConstructionMaster::CreateKey(node->i_id_ + 1, 0, up.ptr());
         tx.scan(Storage::ItemConstructionMaster, low.view(), false, up.view(), true, result);
@@ -970,6 +971,9 @@ public:
       TupleBody* body;
       Status stat = tx.read(Storage::MaterialCostMaster, key.view(), &body);
       if (tx.status_ == TransactionStatus::aborted) return false;
+      // Per CLAUDE.md: tx.read leaves *body unchanged on WARN_NOT_FOUND,
+      // so the cast_to below would dereference a stale pointer.
+      if (stat != Status::OK) return false;
       MaterialCostMaster& mc = body->get_value().cast_to<MaterialCostMaster>();
       cost = mc.mc_stock_price / mc.mc_stock_quantity;
       return true;
@@ -1058,7 +1062,6 @@ public:
 
     template <typename TxExecutor, typename TransactionStatus>
     void run(TxExecutor& tx) {
-        Status stat;
         Query query;
         auto start = query.generate(this, tx);
 
@@ -1260,7 +1263,6 @@ RETRY:
       for (uint32_t i = 0; i < FLAGS_bomb_base_product_size_per_factory; i++) { // all
         auto itr = select_random(rand, product_ids);
         for (uint32_t f_id = 1; f_id <= FLAGS_bomb_factory_size; f_id++) {
-          uint32_t p_id = *itr;
           insert_item_manufacturing_master(0, param, f_id, *itr, 1.0);
           pm_keys.emplace_back(f_id, *itr);
         }

--- a/include/bomb_pessimistic.hh
+++ b/include/bomb_pessimistic.hh
@@ -581,7 +581,9 @@ public:
       if (FLAGS_bomb_use_cache) {
         tx.reconnoiter_begin();
         std::vector<uint32_t> product_ids;
-        auto ret = BombWorkload<Tuple,Param>::select_im_by_factory(tx, 1, product_ids);
+        // Return value intentionally discarded: the reconnaissance pass
+        // populates product_ids, which is all we need here.
+        (void)BombWorkload<Tuple,Param>::select_im_by_factory(tx, 1, product_ids);
         for (auto& p_id : product_ids) {
           Node* root = BombWorkload<Tuple,Param>::build_bom_tree(tx, p_id);
           if (root == nullptr) ERR;
@@ -615,7 +617,6 @@ public:
       while (next.size() != 0) {
         auto node = next.back();
         next.pop_back();
-        auto n = tx.read_set_.size();
         ItemMaster::CreateKey(node->i_id_, item.ptr());
         Status stat = tx.read_lock(Storage::ItemMaster, item.view());
         if (stat != Status::OK) {
@@ -1058,6 +1059,9 @@ public:
       TupleBody* body;
       Status stat = tx.read(Storage::MaterialCostMaster, key.view(), &body);
       if (tx.status_ == TransactionStatus::aborted) return false;
+      // Per CLAUDE.md: tx.read leaves *body unchanged on WARN_NOT_FOUND,
+      // so the cast_to below would dereference a stale pointer.
+      if (stat != Status::OK) return false;
       MaterialCostMaster& mc = body->get_value().cast_to<MaterialCostMaster>();
       cost = mc.mc_stock_price / mc.mc_stock_quantity;
       return true;
@@ -1150,7 +1154,6 @@ public:
 
     template <typename TxExecutor, typename TransactionStatus>
     void run(TxExecutor& tx) {
-        Status stat;
         Query query;
         auto start = query.generate(this, tx);
 
@@ -1374,7 +1377,6 @@ RETRY:
       for (uint32_t i = 0; i < FLAGS_bomb_base_product_size_per_factory; i++) { // all
         auto itr = select_random(rand, product_ids);
         for (uint32_t f_id = 1; f_id <= FLAGS_bomb_factory_size; f_id++) {
-          uint32_t p_id = *itr;
           insert_item_manufacturing_master(0, param, f_id, *itr, 1.0);
           pm_keys.emplace_back(f_id, *itr);
         }

--- a/include/bomb_static.hh
+++ b/include/bomb_static.hh
@@ -33,7 +33,8 @@ public:
       // for static BoM
       tx.begin();
       std::vector<uint32_t> product_ids;
-      auto ret = BombWorkload<Tuple,Param>::select_im_by_factory(tx, 1, product_ids);
+      // Return value intentionally discarded: the call populates product_ids.
+      (void)BombWorkload<Tuple,Param>::select_im_by_factory(tx, 1, product_ids);
       for (auto& p_id : product_ids) {
         Node* root = BombWorkload<Tuple,Param>::build_bom_tree(tx, p_id);
         if (root == nullptr) ERR;

--- a/include/dbomb_deterministic.hh
+++ b/include/dbomb_deterministic.hh
@@ -49,7 +49,8 @@ RETRY:
       uint32_t f_id = query.args.f_id;
       std::vector<uint32_t> product_ids;
       tx.reconnoiter_begin(); // Do target selection as if read from cache
-      Status stat = select_pc_by_factory(tx, f_id, product_ids);
+      // Return value intentionally discarded: the call populates product_ids.
+      (void)select_pc_by_factory(tx, f_id, product_ids);
       tx.reconnoiter_end();
 
       // prepare keys
@@ -92,7 +93,6 @@ RETRY:
       uint32_t i = 0;
       SimpleKey<8> keys[query.args.i_id_set.size()];
       for (auto& m_id : query.args.i_id_set) {
-        SimpleKey<8> key;
         MaterialCostMaster::CreateKey(query.args.f_id, m_id, keys[i].ptr());
         tx.lock_entries_.emplace_back(Storage::MaterialCostMaster, keys[i].view(), true);
         i++;

--- a/include/sbomb_deterministic.hh
+++ b/include/sbomb_deterministic.hh
@@ -33,7 +33,8 @@ public:
       // for static BoM
       tx.begin();
       std::vector<uint32_t> product_ids;
-      auto ret = BombWorkload<Tuple,Param>::select_im_by_factory(tx, 1, product_ids);
+      // Return value intentionally discarded: the call populates product_ids.
+      (void)BombWorkload<Tuple,Param>::select_im_by_factory(tx, 1, product_ids);
       for (auto& p_id : product_ids) {
         Node* root = BombWorkload<Tuple,Param>::build_bom_tree(tx, p_id);
         if (root == nullptr) ERR;
@@ -92,7 +93,6 @@ public:
 
       // prepare keys
       for (auto& m_id : query.args.i_id_set) {
-        SimpleKey<8> key;
         MaterialCostMaster::CreateKey(query.args.f_id, m_id, keys[i].ptr());
         tx.lock_entries_.emplace_back(Storage::MaterialCostMaster, keys[i].view(), true);
         i++;

--- a/include/tpcc/tpcc_tx_delivery.hh
+++ b/include/tpcc/tpcc_tx_delivery.hh
@@ -39,7 +39,9 @@ bool get_order_id(TxExecutor& tx, uint16_t w_id, uint8_t d_id, uint32_t &o_id, b
   SimpleKey<8> left_key, right_key;
   NewOrder::CreateKey(w_id, d_id, 1, left_key.ptr());
   NewOrder::CreateKey(w_id, d_id + 1, 1, right_key.ptr());
-  Status status = tx.scan(Storage::NewOrder, left_key.view(), false, right_key.view(), true, result, 1);
+  // Return value intentionally discarded: the empty-result and aborted
+  // checks below cover both Status::OK and Status::WARN_NOT_FOUND.
+  (void)tx.scan(Storage::NewOrder, left_key.view(), false, right_key.view(), true, result, 1);
   if (tx.status_ == TransactionStatus::aborted) {
     return false;
   }
@@ -62,7 +64,10 @@ template <typename TxExecutor, typename TxStatus>
 bool delete_new_order(TxExecutor& tx, uint16_t w_id, uint8_t d_id, uint32_t o_id) {
   SimpleKey<8> no_key;
   NewOrder::CreateKey(w_id, d_id, o_id, no_key.ptr());
-  Status status = tx.delete_record(Storage::NewOrder, no_key.view());
+  // Return value intentionally discarded: we already verified the row
+  // exists via get_order_id() before calling here, so the only thing left
+  // for the caller to react to is an abort.
+  (void)tx.delete_record(Storage::NewOrder, no_key.view());
   if (tx.status_ == TransactionStatus::aborted) {
     return false;
   }

--- a/include/tpcc/tpcc_tx_orderstatus.hh
+++ b/include/tpcc/tpcc_tx_orderstatus.hh
@@ -66,13 +66,14 @@ bool get_orderline(TxExecutor& tx, uint16_t w_id, uint8_t d_id, uint32_t o_id) {
   SimpleKey<8> left_key, right_key;
   OrderLine::CreateKey(w_id, d_id, o_id, 1, left_key.ptr());
   OrderLine::CreateKey(w_id, d_id, o_id+1, 1, right_key.ptr());
-  Status status = tx.scan(
+  // Return value intentionally discarded: the empty-result and aborted
+  // checks below cover both Status::OK and Status::WARN_NOT_FOUND.
+  (void)tx.scan(
       Storage::OrderLine, left_key.view(), false, right_key.view(), true, result);
   if (tx.status_ == TransactionStatus::aborted) {
     return false;
   }
   for (auto& tuple : result) {
-    TupleBody* body;
     [[maybe_unused]] const OrderLine& ol = tuple->get_value().cast_to<OrderLine>();
   }
   return true;

--- a/include/tpcc/tpcc_tx_stocklevel.hh
+++ b/include/tpcc/tpcc_tx_stocklevel.hh
@@ -47,7 +47,9 @@ bool run_stock_level(TxExecutor& tx, TPCCQuery::StockLevel *query) {
   SimpleKey<8> low, up;
   OrderLine::CreateKey(w_id, d_id, dist->D_NEXT_O_ID - 20, 1, low.ptr());
   OrderLine::CreateKey(w_id, d_id, dist->D_NEXT_O_ID, 1, up.ptr());
-  Status stat = tx.scan(Storage::OrderLine, low.view(), false, up.view(), true, result);
+  // Return value intentionally discarded: empty result and aborted status
+  // checks below cover both Status::OK and Status::WARN_NOT_FOUND.
+  (void)tx.scan(Storage::OrderLine, low.view(), false, up.view(), true, result);
   if (FLAGS_tpcc_interactive_ms) sleepMs(FLAGS_tpcc_interactive_ms);
   if (tx.status_ == TransactionStatus::aborted) {
     return false;

--- a/include/ycsb.hh
+++ b/include/ycsb.hh
@@ -123,11 +123,13 @@ RETRY:
                 TupleBody* body;
                 tx.read(Storage::YCSB, key[i].view(), &body);
                 if (tx.status_ != TransactionStatus::aborted) {
-                  YCSB& t = body->get_value().cast_to<YCSB>();
+                  // Touch the value so the read is not optimized away.
+                  [[maybe_unused]] YCSB& t = body->get_value().cast_to<YCSB>();
                 }
             } else if (pro.ope_ == Ope::WRITE) {
                 obj[i].template allocate<YCSB>();
-                YCSB& t = obj[i].ref();
+                // Materialize the payload before it gets std::move'd into update.
+                [[maybe_unused]] YCSB& t = obj[i].ref();
                 tx.update(Storage::YCSB, key[i].view(), TupleBody(key[i].view(), std::move(obj[i])));
             } else if (pro.ope_ == Ope::READ_MODIFY_WRITE) {
                 TupleBody* body;


### PR DESCRIPTION
[#43](https://github.com/thawk105/ccbench/issues/43) Phase 4 のサブタスク。`-Wunused-variable` 167 件 (file:line:col ユニーク、36 ソースファイル) を潰し、`ccbench_add_protocol()` に `-Werror=unused-variable` を追加する。

## 真のバグ 2 件

### 1. `tx.read()` の戻り値 check 漏れ → stale `body` deref

`include/bomb.hh` と `include/bomb_pessimistic.hh` の `get_material_cost()` で、`tx.read()` の `Status` を `stat` で受けていたが unused のままで、`tx.status_ == aborted` だけ確認して `body->get_value().cast_to<MaterialCostMaster>()` を呼んでいた。CLAUDE.md の "`tx.read` returns Status — *check it*" 節そのままのパターンで、`MaterialCostMaster` 行が無いと前回 read の stale `body` を deref する。両方に `if (stat != Status::OK) return false;` を追加。

### 2. `cc/oze/{bomb,ycsb}_oze.cc` の `actual_extime` print が漏れていた

他の protocol の workload binary (silo / mocc / mvto / si / ss2pl / ermia / cicada / tictoc) は全て `ShowOptParameters()` の後に `std::cout << \"actual_extime:\\t\" << actual_extime << std::endl;` を出力しているが、oze の bomb / ycsb 版だけこの行が無く、`actual_extime` が計算するだけで捨てられていた (`tpcc_oze.cc` は正しく出力している)。print を追加して他の binary と出力スキーマを揃えた。

## カテゴリ別の修正方針

| カテゴリ | 件数 (おおむね) | 方針 |
|---|--:|---|
| 真のバグ (`tx.read` の Status 無視 + stale `body` deref) | 2 | `if (stat != Status::OK) return false;` を追加 |
| 観測性の漏れ (`actual_extime` の print) | 2 | print 行を追加 (他 binary と統一) |
| `Result &myres = std::ref(...)` が `<workload>_<proto>.cc` の worker で完全 dead | 14 | 削除 |
| `uint64_t epoch_timer_start, epoch_timer_stop;` が oze の workload entry で dead | 6 | 削除 |
| `Status stat;` が `run()` 先頭で declare されて未使用 (bomb.hh, bomb_pessimistic.hh) | 2 | 削除 |
| `Version *expected, *desired;` の `expected` が ermia / si の `delete_record` で dead | 2 | `expected` を分離 |
| `SetElement<Tuple>* re;` 等の dead 宣言 (ermia / si / oze) | 多数 | 削除 |
| `bool isInvisible;` (oze) | 3 | 削除 |
| `int num_pages = 0; int num_skip_propagate = 0;` (oze) | 2 | 削除 |
| ループ内で shadowing する dead 宣言 (`uint32_t p_id`, `SimpleKey<8> key`) | 3+ | 削除 |
| `auto n = tx.read_set_.size();` 等の dead snapshot | 2 | 削除 |
| 副作用が目的の値を materialize する `&t = ...` (YCSB の read/write workload、OrderLine の touch) | 数件 | `[[maybe_unused]]` |
| 単に N 回繰り返すだけのループの induction var (`for (auto& k : keys)`) | 2 | `[[maybe_unused]]` |
| 意図的に return を捨てている関数呼び出し (`tx.scan`, `tx.delete_record`, `Masstrees[...].remove_value`, `read_internal`, `select_im_by_factory`, `select_pc_by_factory`) | 多数 | `(void)` + 短いコメント (Phase 1 #47 の `select_im_by_factory` のパターンを踏襲) |

`remove_value` の `(void)` 化は silo / mocc / tictoc / ss2pl / d2pl の writePhase DELETE branch で同じ shape のコードを 5 個別個に直しているが、共通化はこの PR のスコープ外とする。

## CMake

```diff
 target_compile_options(${target} PRIVATE
   -Werror=maybe-uninitialized
   -Werror=unused-but-set-variable
-  -Werror=unused-label)
+  -Werror=unused-label
+  -Werror=unused-variable)
```

## Test plan

- [x] **GCC 13** Release / `-DENABLE_SANITIZER=OFF`: 34/34 binaries built, 0 warnings
- [x] **GCC 11** Debug + ASan: 34/34 binaries built
- [ ] CI 緑

## Related

- #43 Phase 4 (parallel work)
- #50 (Phase 1 完了)