### PR TITLE
docs: CLAUDE.md の人間向け内容を docs/* に切り出して AI 起動 context に純化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,37 @@
 # CLAUDE.md
 
-Context for Claude when working in this repository.
+Startup context for Claude when working in this repository. **このファイルは
+Claude (AI) の起動コンテキスト**。リポジトリの仕様や規約そのものは
+`docs/` 以下に置いてあって、ここからリンクしているだけ。人間 contributor が
+読むべき情報の本体は各 `docs/*.md` を見ること。
 
-## Read before editing
+## Where to start (Claude も人間も)
 
-[docs/coding-conventions.md](docs/coding-conventions.md) — repository
-conventions and file-type-specific best practices (Dockerfile,
-CMake, GitHub Actions workflows, C++, shell, etc.). **Consult the
-relevant section before touching a file of that kind.** When you spot
-a convention worth recording, add it there instead of repeating it in
-PR comments.
+| 知りたいこと | 読む場所 |
+|---|---|
+| リポジトリの全体像、アーキテクチャ、TxExecutor の API 契約、GC 規約 | [docs/architecture.md](docs/architecture.md) |
+| ビルド手順 (cmake, devcontainer, GCC version, build modes) | [docs/build.md](docs/build.md) |
+| 各プロトコルとワークロード対応表、新プロトコルの追加方法 | [docs/protocols.md](docs/protocols.md) |
+| ワークロード仕様 (TPC-C / YCSB / BoMB) | [docs/workloads.md](docs/workloads.md) |
+| 実行時引数 | [docs/runtime-args.md](docs/runtime-args.md) |
+| **ファイル種別ごとのコーディング規約 (Dockerfile / CMake / GHA / C++ / Shell)** | [docs/coding-conventions.md](docs/coding-conventions.md) |
+| **Issue / PR / commit の運用規約 (1 issue = 1 context 等)** | [docs/contributing.md](docs/contributing.md) |
 
-## Read before opening an issue (or PR / commit)
+## Hard rules (これだけは出かける前に確認)
 
-[docs/contributing.md](docs/contributing.md) — issue / PR / commit
-の出し方の規約。**特に「1 issue = 1 context」原則** は読んでから
-立てること。`[P4+P8+P10]` 系の複数コンテキスト混ぜ issue は迷惑なので
-立てない。立っていたら分割する (#37 → #60–#64 の例)。
+1. **編集するファイル種別の規約を [coding-conventions.md](docs/coding-conventions.md)
+   で確認してから書く**。指摘される前に Docker / CMake / C++ の業界 best
+   practice を適用する。
+2. **`tx.read` の戻り値は必ず check する**。
+   [coding-conventions.md § `tx.read` returns Status](docs/coding-conventions.md)
+   を参照。ここをサボると Debug+ASan で `HeapObject::cast_to` で死ぬか、
+   Release で garbage data を読み出す。
+3. **Issue を立てるときは 1 context に絞る**。
+   [contributing.md](docs/contributing.md) を参照。`[P4+P8+P10]` 系の
+   複数コンテキスト混ぜは過去にやって分割した経緯 (#37 → #60〜#64)。
+4. **Werror promotion 系の作業は GCC 13 (CI と同じ) でローカル確認する**。
+   devcontainer も CI も `ubuntu:24.04` ベースの GCC 13 に揃えてある
+   ([docs/build.md § Compiler version](docs/build.md))。
 
 ## Where to record what you learn (CLAUDE.md / docs vs Claude memory)
 
@@ -29,167 +44,28 @@ destination when recording something new:
 
 - **Goes in this repo (CLAUDE.md / docs/)** if a human contributor would
   also need it to work effectively on the codebase:
-  - Repository facts (architecture, build flow, protocol matrix, etc.)
-  - Coding conventions adopted by the project
+  - Repository facts (architecture, build flow, protocol matrix, etc.) →
+    `docs/architecture.md`, `docs/build.md`, `docs/protocols.md`
+  - Coding conventions adopted by the project → `docs/coding-conventions.md`
+  - Process / governance (issue・PR・commit) → `docs/contributing.md`
   - Decision rationale that future maintainers will want to look up
 - **Goes in Claude memory (private to one Claude instance)** if it's
   personal to how *this* Claude collaborates with *this* user:
   - User preferences ("reply in Japanese", "no Co-Authored-By trailer")
   - Claude's own behavioral heuristics (parallelization rules,
-    prompt-writing patterns)
+    prompt-writing patterns, resource judgement)
   - "Last time I made mistake X, the user's fix was Y" — reminders for
     future Claude turns, not for human review
 
 Rule of thumb: **"would a new contributor cloning the repo need this?"**
-→ yes → repo; → no → memory. Personal preferences and Claude-side
-heuristics specifically **should not** be committed to CLAUDE.md or
-`docs/` — that pollutes the shared repo with one person's taste.
+→ yes → repo (`docs/*` first, fall back to `CLAUDE.md` only if it's
+genuinely AI-only meta); → no → memory. Personal preferences and
+Claude-side heuristics specifically **should not** be committed to
+CLAUDE.md or `docs/` — that pollutes the shared repo with one person's
+taste.
 
-## What this repo is
+## このファイルを膨らませないこと
 
-CCBench re-implements major in-memory concurrency-control protocols on a common substrate so they can be compared on identical workloads (Tanabe et al., VLDB 2020). The repository now also bundles the **TPC-C** and **BoMB** workloads and several extra protocols, contributed by [@jnmt](https://github.com/jnmt) on the `vldb-paper` branch and merged here.
-
-Three workloads:
-
-- **TPC-C** — the standard OLTP benchmark
-- **YCSB** — key-value workload (read/write ratio, zipfian skew, etc.)
-- **BoMB** — Bill-of-Materials Benchmark (long-running product costing + short OLTP txns)
-
-Workload specs are in [docs/workloads.md](docs/workloads.md).
-
-## Target environment
-
-- **OS**: x86_64 Linux (Debian/Ubuntu). Not portable to macOS.
-- **Why**: code uses x86 intrinsics (`__cpuid_count` in [include/cpu.hh](include/cpu.hh)) and Linux-only APIs (`sched_setaffinity`, `SYS_gettid`, `<linux/fs.h>` in [include/fileio.hh](include/fileio.hh)).
-- **CI**: GitHub Actions on `ubuntu-latest` — see [.github/workflows/build.yml](.github/workflows/build.yml). It triggers on push to any branch and on PRs; ccache + apt + bootstrap output are all cached.
-
-## Working from macOS
-
-Use the devcontainer at [.devcontainer/](.devcontainer/) (`Dev Containers: Reopen in Container` in VS Code). It pins `linux/amd64`, so on Apple Silicon it runs under QEMU emulation.
-
-- ✅ Editing, compiling, unit tests, correctness checks
-- ❌ **Performance benchmarks** — numbers from QEMU are meaningless. Use a real x86_64 Linux box for any measurement.
-
-## Build flow
-
-After cloning (or after `Reopen in Container` finishes submodule init):
-
-```
-./build_tools/bootstrap.sh             # masstree
-./build_tools/bootstrap_mimalloc.sh    # mimalloc
-./build_tools/bootstrap_googletest.sh  # googletest
-```
-
-Then build everything in one shot from the repo root using the top-level [CMakeLists.txt](CMakeLists.txt):
-
-```
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
-cmake --build build -j
-```
-
-Or build one specific target:
-
-```
-cmake --build build --target tpcc_silo.exe   # binary lands in build/cc/silo/
-```
-
-The top-level CMake auto-enables **ccache** as a compiler launcher if `ccache` is on PATH, deduplicating compilations across the ~28 binaries (full warm rebuild ≈ 3 sec vs 30+ sec cold). Disable with `-DCCBENCH_CCACHE=OFF`.
-
-`bootstrap_tbb.sh` references `third_party/tbb`, which is **not** registered as a submodule. Skip it unless you add tbb manually.
-
-## Protocols and workload coverage
-
-All CC protocols live under [cc/](cc/) — `cc/silo/`, `cc/cicada/`, etc. Each one's [CMakeLists.txt](cc/silo/CMakeLists.txt) is a single declarative `ccbench_add_protocol(...)` call (see [cmake/ProtocolHelpers.cmake](cmake/ProtocolHelpers.cmake)); the top-level [CMakeLists.txt](CMakeLists.txt) iterates over them. Each produces one binary per supported workload, named `<workload>_<protocol>.exe`, landing in `build/cc/<protocol>/`.
-
-The support matrix is **auto-generated** at configure time from the `WORKLOADS` argument of every `ccbench_add_protocol(...)` call into `build/PROTOCOL_MATRIX.md`. Don't hand-edit a copy of it here — re-run cmake and paste the file contents if you need a snapshot:
-
-| Protocol | YCSB | TPC-C | BoMB | sBoMB / dBoMB |
-|---|:-:|:-:|:-:|:-:|
-| `cc/silo/`   | ✓ | ✓ | ✓ | sBoMB |
-| `cc/mocc/`   | ✓ | ✓ | ✓ | sBoMB |
-| `cc/cicada/` | ✓ | ✓ | ✓ | sBoMB |
-| `cc/ermia/`  | ✓ | ✓ | ✓ | sBoMB |
-| `cc/tictoc/` | ✓ | ✓ | ✓ | sBoMB |
-| `cc/oze/`    | ✓ | ✓ | ✓ | — |
-| `cc/si/`     | ✓ | ✓ | ✓ | sBoMB |
-| `cc/ss2pl/`  | — | ✓ | ✓ | — |
-| `cc/mvto/`   | — | ✓ | ✓ | — |
-| `cc/d2pl/`   | — | — | ✓ | sBoMB + dBoMB |
-
-**Not built by default** ([CMakeLists.txt](CMakeLists.txt) keeps the line commented):
-- [cc/occ/](cc/occ/) — present in tree but uses a plain Makefile on the legacy uint64-key API, not wired into the CMake tree.
-
-`cc/si/` is a fresh implementation derived from `cc/ermia/` by stripping the SSN (Serial Safety Net) layer; the original legacy `si/` (uint64-key API) was replaced. `cc/d2pl/` deliberately doesn't support TPC-C — its deterministic locking model needs pre-declared `lock_entries_`, which the optimistic-style TPC-C templates don't provide.
-
-### Adding or tuning a protocol
-
-A protocol's CMakeLists.txt is a single function call:
-
-```cmake
-ccbench_add_protocol(<name>
-  SOURCES   <shared .cc files>                # do NOT list workload entry points
-  WORKLOADS ycsb tpcc bomb sbomb              # any subset of these tags
-  OPTIONS                                     # protocol-specific -D defines
-    FOO=${CCBENCH_FOO}
-    BAR                                       # bare flag = `-DBAR` (no value)
-)
-```
-
-Universal `-D` flags (`KEY_SIZE`, `VAL_SIZE`, `BACK_OFF`, `ADD_ANALYSIS`, `MASSTREE_USE`) and the link against `ccbench_common` + `ccbench::masstree` + `ccbench::mimalloc` are added automatically. New cache options go in [cmake/Options.cmake](cmake/Options.cmake). An `OPTIONS` entry whose value is empty is dropped — same as the old `remove_definitions(-DFLAG)` path.
-
-## Implementation notes
-
-### Common transaction API (compile-time enforced)
-
-All built protocols expose the same `TxExecutor` API expected by the workload templates in [include/tpcc.hh](include/tpcc.hh), [include/bomb.hh](include/bomb.hh), [include/ycsb.hh](include/ycsb.hh):
-
-```cpp
-Status read(Storage s, std::string_view key, TupleBody** body);
-Status update(Storage s, std::string_view key, TupleBody&& body);   // SQL UPDATE; returns WARN_NOT_FOUND if row absent
-Status insert(Storage s, std::string_view key, TupleBody&& body);   // SQL INSERT
-Status delete_record(Storage s, std::string_view key);
-Status scan(..., std::vector<TupleBody*>& result);
-Status scan(..., std::vector<TupleBody*>& result, int64_t limit);   // limit form is required (TPC-C uses it)
-bool   commit();
-void   abort();
-```
-
-This contract is **enforced at compile time** by [include/tx_executor_concept.hh](include/tx_executor_concept.hh). Each protocol's `transaction.hh` ends with `static_assert(TxExecutorLike<TxExecutor>);`, so a missing or wrong-signature method fails the protocol's own build with a named diagnostic — no more "ran fine, then crashed inside TPC-C delivery because the limit overload of `scan` was missing".
-
-The check uses an `is_detected`-style SFINAE helper instead of a C++20 `concept` because the bundled `masstree-beta` upstream still calls `std::allocator::construct/destroy` (removed in C++20), pinning the whole tree to C++17.
-
-### `tx.read` returns Status — *check it*
-
-`tx.read` returns `Status::OK` on hit and `Status::WARN_NOT_FOUND` on miss. On miss, `*body` is **left unchanged** (it does not get nullified). Checking only `tx.status_ == TransactionStatus::aborted` is not enough — a stale `body` pointer from a previous read will silently get dereferenced, which manifests as a `HeapObject::cast_to` assertion under Debug+ASan and as garbage data in Release. Always:
-
-```cpp
-Status stat = tx.read(s, key, &body);
-if (tx.status_ == TransactionStatus::aborted) return false;
-if (stat != Status::OK) return false;   // do not skip this
-```
-
-### Per-thread GC + cross-thread Tuple references
-
-`cc/ermia/` and `cc/si/` keep a per-thread `gcq_for_version_` (entries reference `Tuple*` via `rcdptr_`) plus a per-thread `gcq_for_record_` (`Tuple*` itself). A `Tuple` deleted by Thread A goes only into A's `gcq_for_record_`, but Thread B's `gcq_for_version_` may still reference it. To avoid UAF in `gcRecord`, both protocols use an EBR-style guard: each thread publishes the smallest cstamp in its `gcq_for_version_` to `MinQueuedCstamp[thid]` on push (in commit) and after the pop loop in `gcVersion`; `gcRecord` only frees a Tuple whose delete cstamp is strictly less than the global min. **If you change either GC queue's push/pop sites, keep the publish call in sync** — see comments in [cc/si/garbage_collection.cc](cc/si/garbage_collection.cc) and [cc/ermia/garbage_collection.cc](cc/ermia/garbage_collection.cc).
-
-### Build modes for development
-
-- **Debug+ASan** (the default top-level Debug build) is the right mode for correctness work — most TPC-C bugs we have caught (use-after-free in `get_and_update_*`, the `cast_to<Order>` assertion, the gcRecord UAF) showed up there first and were invisible under pure Release.
-- **Release** is for benchmark numbers only. CI builds Release without sanitizer (`-DENABLE_SANITIZER=OFF`) — it does not run binaries, just verifies they compile.
-
-### Compiler version
-
-Both the devcontainer (`ubuntu:24.04` base, see [.devcontainer/Dockerfile](.devcontainer/Dockerfile)) and CI (`ubuntu-latest`) ship **GCC 13**, so what builds in the devcontainer also builds in CI. This wasn't always true — see #44, where GCC 11 in an older devcontainer disagreed with CI's GCC 13 on `-Wmaybe-uninitialized` and burned three CI cycles before the gap was closed.
-
-## Repository layout
-
-- [include/](include/) — shared headers (atomics, rwlock, zipf, masstree wrapper, etc.)
-- [include/tpcc/](include/tpcc/) — unified TPC-C framework (tables, queries, 5 transactions)
-- [include/ycsb.hh](include/ycsb.hh), [include/bomb.hh](include/bomb.hh), [include/bomb_pessimistic.hh](include/bomb_pessimistic.hh), [include/dbomb_deterministic.hh](include/dbomb_deterministic.hh), [include/sbomb_deterministic.hh](include/sbomb_deterministic.hh), [include/workload.hh](include/workload.hh) — workload entry points
-- [common/](common/) — shared sources used across protocols
-- [cc/](cc/) — one subdirectory per concurrency control protocol (`cc/silo/`, `cc/cicada/`, …), each with a single-call `CMakeLists.txt` and the `<workload>_<protocol>.cc` entry points
-- [third_party/](third_party/) — submodules: `masstree`, `mimalloc`, `googletest`, `spdlog`
-- [build_tools/](build_tools/) — bootstrap scripts and `ubuntu.deps` (apt package list)
-- [cmake/](cmake/) — shared CMake modules: `CompileOptions.cmake`, [Options.cmake](cmake/Options.cmake) (universal `-D` flags), [ProtocolHelpers.cmake](cmake/ProtocolHelpers.cmake) (`ccbench_add_protocol`)
-- [docs/](docs/) — `build.md`, `workloads.md`, `protocols.md`, `runtime-args.md`
-- [instruction/](instruction/) — micro-benchmarks for individual instructions (cache, fetch_add, etc.)
+CLAUDE.md は **目次 + AI 向けメタ情報** で短く保つ。リポジトリの事実
+や規約を書きたくなったら `docs/*` に書き、ここからリンクする。長く
+なってきたら切り出すサイン。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,53 @@
+# Architecture
+
+リポジトリの全体像と、各プロトコルが従う内部規約をまとめる。ビルド手順は [build.md](build.md)、プロトコル × ワークロードの対応表は [protocols.md](protocols.md)、ワークロード仕様は [workloads.md](workloads.md) を参照。
+
+## What this repo is
+
+CCBench re-implements major in-memory concurrency-control protocols on a common substrate so they can be compared on identical workloads (Tanabe et al., VLDB 2020). The repository now also bundles the **TPC-C** and **BoMB** workloads and several extra protocols, contributed by [@jnmt](https://github.com/jnmt) on the `vldb-paper` branch and merged here.
+
+Three workloads:
+
+- **TPC-C** — the standard OLTP benchmark
+- **YCSB** — key-value workload (read/write ratio, zipfian skew, etc.)
+- **BoMB** — Bill-of-Materials Benchmark (long-running product costing + short OLTP txns)
+
+Workload specs are in [workloads.md](workloads.md).
+
+## Repository layout
+
+- [include/](../include/) — shared headers (atomics, rwlock, zipf, masstree wrapper, etc.)
+- [include/tpcc/](../include/tpcc/) — unified TPC-C framework (tables, queries, 5 transactions)
+- [include/ycsb.hh](../include/ycsb.hh), [include/bomb.hh](../include/bomb.hh), [include/bomb_pessimistic.hh](../include/bomb_pessimistic.hh), [include/dbomb_deterministic.hh](../include/dbomb_deterministic.hh), [include/sbomb_deterministic.hh](../include/sbomb_deterministic.hh), [include/workload.hh](../include/workload.hh) — workload entry points
+- [common/](../common/) — shared sources used across protocols
+- [cc/](../cc/) — one subdirectory per concurrency control protocol (`cc/silo/`, `cc/cicada/`, …), each with a single-call `CMakeLists.txt` and the `<workload>_<protocol>.cc` entry points
+- [third_party/](../third_party/) — submodules: `masstree`, `mimalloc`, `googletest`, `spdlog`
+- [build_tools/](../build_tools/) — bootstrap scripts and `ubuntu.deps` (apt package list)
+- [cmake/](../cmake/) — shared CMake modules: `CompileOptions.cmake`, [Options.cmake](../cmake/Options.cmake) (universal `-D` flags), [ProtocolHelpers.cmake](../cmake/ProtocolHelpers.cmake) (`ccbench_add_protocol`)
+- [docs/](.) — this directory
+- [instruction/](../instruction/) — micro-benchmarks for individual instructions (cache, fetch_add, etc.)
+
+## Common transaction API (compile-time enforced)
+
+All built protocols expose the same `TxExecutor` API expected by the workload templates in [include/tpcc.hh](../include/tpcc.hh), [include/bomb.hh](../include/bomb.hh), [include/ycsb.hh](../include/ycsb.hh):
+
+```cpp
+Status read(Storage s, std::string_view key, TupleBody** body);
+Status update(Storage s, std::string_view key, TupleBody&& body);   // SQL UPDATE; returns WARN_NOT_FOUND if row absent
+Status insert(Storage s, std::string_view key, TupleBody&& body);   // SQL INSERT
+Status delete_record(Storage s, std::string_view key);
+Status scan(..., std::vector<TupleBody*>& result);
+Status scan(..., std::vector<TupleBody*>& result, int64_t limit);   // limit form is required (TPC-C uses it)
+bool   commit();
+void   abort();
+```
+
+This contract is **enforced at compile time** by [include/tx_executor_concept.hh](../include/tx_executor_concept.hh). Each protocol's `transaction.hh` ends with `static_assert(TxExecutorLike<TxExecutor>);`, so a missing or wrong-signature method fails the protocol's own build with a named diagnostic — no more "ran fine, then crashed inside TPC-C delivery because the limit overload of `scan` was missing".
+
+The check uses an `is_detected`-style SFINAE helper instead of a C++20 `concept` because the bundled `masstree-beta` upstream still calls `std::allocator::construct/destroy` (removed in C++20), pinning the whole tree to C++17.
+
+The semantics of `tx.read` (Status return, miss-handling) are non-obvious and are written up as a coding rule in [coding-conventions.md § C++](coding-conventions.md).
+
+## Per-thread GC + cross-thread Tuple references
+
+`cc/ermia/` and `cc/si/` keep a per-thread `gcq_for_version_` (entries reference `Tuple*` via `rcdptr_`) plus a per-thread `gcq_for_record_` (`Tuple*` itself). A `Tuple` deleted by Thread A goes only into A's `gcq_for_record_`, but Thread B's `gcq_for_version_` may still reference it. To avoid UAF in `gcRecord`, both protocols use an EBR-style guard: each thread publishes the smallest cstamp in its `gcq_for_version_` to `MinQueuedCstamp[thid]` on push (in commit) and after the pop loop in `gcVersion`; `gcRecord` only frees a Tuple whose delete cstamp is strictly less than the global min. **If you change either GC queue's push/pop sites, keep the publish call in sync** — see comments in [cc/si/garbage_collection.cc](../cc/si/garbage_collection.cc) and [cc/ermia/garbage_collection.cc](../cc/ermia/garbage_collection.cc).

--- a/docs/build.md
+++ b/docs/build.md
@@ -4,9 +4,14 @@
 
 CCBench targets x86_64 Linux (Debian/Ubuntu). It uses x86 intrinsics
 (`__cpuid_count` in [include/cpu.hh](../include/cpu.hh)) and Linux-only APIs
-(`sched_setaffinity`, `<linux/fs.h>` in [include/fileio.hh](../include/fileio.hh)),
+(`sched_setaffinity`, `SYS_gettid`, `<linux/fs.h>` in [include/fileio.hh](../include/fileio.hh)),
 so it does not build natively on macOS or other platforms. For development
 on macOS, use the [devcontainer](#devcontainer-on-macos--non-ubuntu-hosts).
+
+CI runs on GitHub Actions `ubuntu-latest` — see
+[.github/workflows/build.yml](../.github/workflows/build.yml). It triggers
+on push to any branch and on PRs; ccache + apt + bootstrap output are all
+cached.
 
 Install build dependencies (this is what CI uses):
 
@@ -65,6 +70,29 @@ for the universal build-time tunables (`CCBENCH_KEY_SIZE`, `CCBENCH_BACK_OFF`,
 etc.) that can be overridden on the cmake command line. See
 [protocols.md](protocols.md) for the list of protocols and which workloads
 they support.
+
+The top-level CMake auto-enables **ccache** as a compiler launcher if `ccache`
+is on PATH, deduplicating compilations across the ~34 binaries (full warm
+rebuild ≈ 3 sec vs 30+ sec cold). Disable with `-DCCBENCH_CCACHE=OFF`.
+
+## Build modes for development
+
+- **Debug+ASan** (the default top-level Debug build) is the right mode for
+  correctness work — most TPC-C bugs we have caught (use-after-free in
+  `get_and_update_*`, the `cast_to<Order>` assertion, the gcRecord UAF)
+  showed up there first and were invisible under pure Release.
+- **Release** is for benchmark numbers only. CI builds Release without
+  sanitizer (`-DENABLE_SANITIZER=OFF`) — it does not run binaries, just
+  verifies they compile.
+
+## Compiler version
+
+Both the devcontainer (`ubuntu:24.04` base, see
+[.devcontainer/Dockerfile](../.devcontainer/Dockerfile)) and CI
+(`ubuntu-latest`) ship **GCC 13**, so what builds in the devcontainer also
+builds in CI. This wasn't always true — see #44, where GCC 11 in an older
+devcontainer disagreed with CI's GCC 13 on `-Wmaybe-uninitialized` and
+burned three CI cycles before the gap was closed.
 
 ## Devcontainer (on macOS / non-Ubuntu hosts)
 

--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -52,14 +52,32 @@
 
 ## C++
 
-- **`tx.read` の戻り値は必ず check する** (CLAUDE.md の "tx.read returns
-  Status — check it" セクション参照)。
+- **`tx.read` の戻り値は必ず check する**。詳細は下記 [`tx.read` returns Status — *check it*](#txread-returns-status--check-it)。
 - **未初期化のローカル変数は宣言時に default-init する** (`int x = 0;` /
   `T* p = nullptr;`)。GCC 13 の `-Wmaybe-uninitialized` が
   [#44](https://github.com/thawk105/ccbench/pull/44) で実バグを表面化した
   経緯あり。
 - **`auto` で受けた `Status` を読み捨てない**。意図的に捨てたい場合は
   `(void) func(...)` + 理由のコメント、捨てたくない場合は明示的に check。
+
+### `tx.read` returns Status — *check it*
+
+`tx.read` returns `Status::OK` on hit and `Status::WARN_NOT_FOUND` on miss.
+On miss, `*body` is **left unchanged** (it does not get nullified). Checking
+only `tx.status_ == TransactionStatus::aborted` is not enough — a stale
+`body` pointer from a previous read will silently get dereferenced, which
+manifests as a `HeapObject::cast_to` assertion under Debug+ASan and as
+garbage data in Release. Always:
+
+```cpp
+Status stat = tx.read(s, key, &body);
+if (tx.status_ == TransactionStatus::aborted) return false;
+if (stat != Status::OK) return false;   // do not skip this
+```
+
+これは過去 PR #58 で実際に `get_material_cost()` で抜けていた箇所が
+`-Werror=unused-variable` で表面化したことがある — レビューで指摘する前に
+ここを読む / 書く側で意識する。
 
 ## Shell スクリプト
 

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -21,7 +21,56 @@ for the declarative helper). All are driven from the top-level
 
 `cc/si` was rewritten by stripping the SSN layer from `cc/ermia` (the
 original `si/` was on the legacy uint64-key API and excluded from the
-build).
+build). `cc/d2pl` deliberately doesn't support TPC-C — its deterministic
+locking model needs pre-declared `lock_entries_`, which the optimistic-style
+TPC-C templates don't provide.
+
+## sBoMB / dBoMB support
+
+Each protocol's support for sBoMB (single-threaded BoMB) and dBoMB
+(deterministic BoMB) is in [build/PROTOCOL_MATRIX.md](../build/PROTOCOL_MATRIX.md),
+which is **auto-generated** at CMake configure time from the `WORKLOADS`
+argument of every `ccbench_add_protocol(...)` call. The current snapshot:
+
+| Protocol | YCSB | TPC-C | BoMB | sBoMB | dBoMB |
+|---|:-:|:-:|:-:|:-:|:-:|
+| `cc/silo/`   | ✓ | ✓ | ✓ | ✓ | — |
+| `cc/mocc/`   | ✓ | ✓ | ✓ | ✓ | — |
+| `cc/cicada/` | ✓ | ✓ | ✓ | ✓ | — |
+| `cc/ermia/`  | ✓ | ✓ | ✓ | ✓ | — |
+| `cc/tictoc/` | ✓ | ✓ | ✓ | ✓ | — |
+| `cc/oze/`    | ✓ | ✓ | ✓ | — | — |
+| `cc/si/`     | ✓ | ✓ | ✓ | ✓ | — |
+| `cc/ss2pl/`  | — | ✓ | ✓ | — | — |
+| `cc/mvto/`   | — | ✓ | ✓ | — | — |
+| `cc/d2pl/`   | — | — | ✓ | ✓ | ✓ |
+
+**Don't hand-edit a copy of this table** — re-run cmake and check
+`build/PROTOCOL_MATRIX.md` if you need an up-to-date snapshot.
+
+## Adding or tuning a protocol
+
+A protocol's CMakeLists.txt is a single function call:
+
+```cmake
+ccbench_add_protocol(<name>
+  SOURCES   <shared .cc files>                # do NOT list workload entry points
+  WORKLOADS ycsb tpcc bomb sbomb              # any subset of these tags
+  OPTIONS                                     # protocol-specific -D defines
+    FOO=${CCBENCH_FOO}
+    BAR                                       # bare flag = `-DBAR` (no value)
+)
+```
+
+Universal `-D` flags (`KEY_SIZE`, `VAL_SIZE`, `BACK_OFF`, `ADD_ANALYSIS`,
+`MASSTREE_USE`) and the link against `ccbench_common` +
+`ccbench::masstree` + `ccbench::mimalloc` are added automatically. New
+cache options go in [cmake/Options.cmake](../cmake/Options.cmake). An
+`OPTIONS` entry whose value is empty is dropped — same as the old
+`remove_definitions(-DFLAG)` path.
+
+After adding a new protocol directory, list it in the `foreach(_proto …)`
+loop in the top-level [CMakeLists.txt](../CMakeLists.txt).
 
 ## Not built by default
 


### PR DESCRIPTION
## 動機

CLAUDE.md は「Claude 向け」と命名されつつ、実体は **リポジトリ仕様 + ビルド手順 + protocol matrix + 内部規約 + AI 向け hint が全部混ざった hybrid** だった。人間 contributor が「AI 用リマインダ (\`tx.read\` の Status check 等)」も読む羽目になっていて、ユーザーから「AI 向けと人間向けは分けるべき。AI レビュー観点をわざわざ人間に読ませるの可哀想やない?」と指摘あり。

## 方針 (β 案: 既存構造の延長)

- 既存 \`docs/\*\` (人間+AI 共有) に内容を移動
- CLAUDE.md は **AI 起動 context + 各 docs への目次 + Claude memory との使い分け** だけに圧縮 (195 → 71 行)
- AI/人間分離は \"ファイル単位\" で達成。同じ規約を 2 か所に書く重複は作らない

## 移動先マッピング

| CLAUDE.md にあった節 | 行き先 |
|---|---|
| What this repo is | \`docs/architecture.md\` (新規) |
| Repository layout | \`docs/architecture.md\` |
| Common transaction API (compile-time enforced) | \`docs/architecture.md\` |
| Per-thread GC + cross-thread Tuple references | \`docs/architecture.md\` |
| Target environment の CI/GCC 13 note | \`docs/build.md\` 追記 |
| Build flow / Working from macOS | (既に \`docs/build.md\` にあった、新規追記なし) |
| Build modes for development | \`docs/build.md\` 追記 |
| Compiler version (devcontainer ↔ CI = GCC 13 統一) | \`docs/build.md\` 追記 |
| Protocols and workload coverage (matrix) | \`docs/protocols.md\` 充実 (sBoMB/dBoMB 列追加) |
| Adding or tuning a protocol | \`docs/protocols.md\` 追記 |
| \`tx.read\` returns Status — *check it* | \`docs/coding-conventions.md\` C++ 節に subsection 化 (規約の正典) |

## CLAUDE.md に残ったもの

1. **Where to start**: 各 \`docs/\*\` への目次表 (Claude が最初に読む)
2. **Hard rules**: 4 つの守れリスト (coding-conventions 参照、\`tx.read\` check、1 issue = 1 context、Werror は GCC 13 でローカル確認)
3. **Where to record what you learn**: Claude memory との使い分け (AI 特有のメタ情報、人間 contributor は読まなくていい)
4. **このファイルを膨らませないこと**: 自己制約 (CLAUDE.md は目次に保つ)

## 検証

- ファイルサイズ: CLAUDE.md 195 → 71 行 (-63%)
- 全相対リンクが resolve することを Python で確認 (broken links: 0)

## 多言語化との関係

ユーザー提案の \`_ja\` / \`_en\` 多言語化は **別 PR** にスコープ分割。

理由:
- 多言語化は \"原典をどちらにするか\" \"AI 自動翻訳の CI workflow\" など別軸の判断が必要
- この PR は AI/人間分離だけにフォーカスして焦点を絞る
- 多言語化版は新 docs/* も対象になるので、この PR がマージされてからの方が clean

## Test plan

- [x] 全相対リンクが resolve
- [ ] CI 緑 (\`.md\` のみだが念のため)
- [ ] レビューで「人間が読むべき情報が CLAUDE.md にしかない」「逆に AI 特有メタが docs/* に紛れている」がないか確認