### PR TITLE
Phase 2: -Wignored-qualifiers を潰して -Werror=ignored-qualifiers を有効化

### DIFF
--- a/cmake/ProtocolHelpers.cmake
+++ b/cmake/ProtocolHelpers.cmake
@@ -54,7 +54,8 @@ function(ccbench_add_protocol name)
       -Werror=reorder
       -Werror=unused-parameter
       -Werror=catch-value
-      -Werror=unused-variable)
+      -Werror=unused-variable
+      -Werror=ignored-qualifiers)
 
     set_property(TARGET ${target} PROPERTY CCBENCH_PROTOCOL "${name}")
     set_property(TARGET ${target} PROPERTY CCBENCH_WORKLOAD "${wl}")

--- a/include/bomb.hh
+++ b/include/bomb.hh
@@ -503,15 +503,15 @@ public:
       }
     };
 
-    static const uint32_t get_i_id_product_start() {
+    static uint32_t get_i_id_product_start() {
       return 1;
     }
 
-    static const uint32_t get_i_id_material_start() {
+    static uint32_t get_i_id_material_start() {
       return get_i_id_product_start() + FLAGS_bomb_product_size;
     }
 
-    static const uint32_t get_i_id_work_start() {
+    static uint32_t get_i_id_work_start() {
       return get_i_id_material_start() + FLAGS_bomb_material_size;
     }
 

--- a/include/bomb_pessimistic.hh
+++ b/include/bomb_pessimistic.hh
@@ -537,15 +537,15 @@ public:
       }
     };
 
-    static const uint32_t get_i_id_product_start() {
+    static uint32_t get_i_id_product_start() {
       return 1;
     }
 
-    static const uint32_t get_i_id_material_start() {
+    static uint32_t get_i_id_material_start() {
       return get_i_id_product_start() + FLAGS_bomb_product_size;
     }
 
-    static const uint32_t get_i_id_work_start() {
+    static uint32_t get_i_id_work_start() {
       return get_i_id_material_start() + FLAGS_bomb_material_size;
     }
 


### PR DESCRIPTION
[#43](https://github.com/thawk105/ccbench/issues/43) Phase 2 のサブタスク。`-Wignored-qualifiers` の警告を潰し、`ccbench_add_protocol()` に `-Werror=ignored-qualifiers` を追加する。

## 修正概要

GCC 13 build で得た hits は実体 6 箇所 (`include/bomb.hh` x3 行 + `include/bomb_pessimistic.hh` x3 行) のみ。複数プロトコルから include されるためコンパイル単位ごとに重複していたが、ユニーク行は次のとおり。

| ファイル | 関数 | 修正内容 |
|---|---|---|
| `include/bomb.hh` L506 | `get_i_id_product_start()` | 値返却の `const uint32_t` から `const` 削除 |
| `include/bomb.hh` L510 | `get_i_id_material_start()` | 同上 |
| `include/bomb.hh` L514 | `get_i_id_work_start()` | 同上 |
| `include/bomb_pessimistic.hh` L540 | `get_i_id_product_start()` | 同上 |
| `include/bomb_pessimistic.hh` L544 | `get_i_id_material_start()` | 同上 |
| `include/bomb_pessimistic.hh` L548 | `get_i_id_work_start()` | 同上 |

いずれも「値返却関数の return type に付いた top-level `const`」パターン。`const uint32_t` を値で返しても呼び出し側からは `uint32_t` と区別がつかず、`-Wignored-qualifiers` が正しく no-op qualifier として検出していた。**真のバグ (UB / 動作差分) を生むコードは無し** — 純粋にノイズの削除。

## CMake

`cmake/ProtocolHelpers.cmake` の `target_compile_options` 末尾に `-Werror=ignored-qualifiers` を追加 (既存 7 行は変更なし)。

## Test plan

- [x] GCC 13 Release / `-DENABLE_SANITIZER=OFF`: 34/34 ビルド成功
- [x] GCC 11 Debug + ASan: 34/34 ビルド成功
- [ ] CI 緑

## Related

- #43 Phase 2 (parallel work — sibling `-Wsign-compare` PR is in flight separately)