### PR TITLE
Phase 2: -Wsign-compare を潰して -Werror=sign-compare を有効化

### DIFF
--- a/cc/oze/util.cc
+++ b/cc/oze/util.cc
@@ -40,7 +40,7 @@ void init(int32_t table_num) {
   for (unsigned int i = 0; i < TotalThreadNum; ++i) {
     ThManagementTable[i] = new ThreadManagementEntry(1, FLAGS_cc_mode);
   }
-  for (unsigned int i = 0; i < table_num * 2; ++i) {
+  for (unsigned int i = 0; i < static_cast<unsigned int>(table_num) * 2; ++i) {
     ScanHistory[i].store(nullptr);
   }
 }

--- a/cmake/ProtocolHelpers.cmake
+++ b/cmake/ProtocolHelpers.cmake
@@ -55,7 +55,8 @@ function(ccbench_add_protocol name)
       -Werror=unused-parameter
       -Werror=catch-value
       -Werror=unused-variable
-      -Werror=ignored-qualifiers)
+      -Werror=ignored-qualifiers
+      -Werror=sign-compare)
 
     set_property(TARGET ${target} PROPERTY CCBENCH_PROTOCOL "${name}")
     set_property(TARGET ${target} PROPERTY CCBENCH_WORKLOAD "${wl}")

--- a/include/bomb.hh
+++ b/include/bomb.hh
@@ -300,7 +300,7 @@ public:
         rnd_.init();
 
         if (!FLAGS_bomb_mixed_mode) {
-          int total_threads = FLAGS_bomb_l1_thread_num
+          uint64_t total_threads = FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num
                               + FLAGS_bomb_s2_thread_num
                               + FLAGS_bomb_s3_thread_num
@@ -438,22 +438,27 @@ public:
       TxArgs args;
 
       TxType decideType(TxExecutor& tx, [[maybe_unused]] Xoroshiro128Plus& r) {
+        // tx.thid_ is a non-negative thread index whose underlying type varies
+        // between protocols (int / size_t / uint8_t / unsigned int). Cast it
+        // to uint32_t once so each comparison against FLAGS_bomb_*_thread_num
+        // (declared as uint32) is sign-clean.
+        const uint32_t thid = static_cast<uint32_t>(tx.thid_);
         TxType txType;
-        if (tx.thid_ < FLAGS_bomb_l1_thread_num) {
+        if (thid < FLAGS_bomb_l1_thread_num) {
           txType = TxType::UpdateProductCostMaster;
-        } else if (tx.thid_ < FLAGS_bomb_l1_thread_num
+        } else if (thid < FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num) {
           txType = TxType::UpdateMaterialCostMaster;
-        } else if (tx.thid_ < FLAGS_bomb_l1_thread_num
+        } else if (thid < FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num
                               + FLAGS_bomb_s2_thread_num) {
           txType = TxType::IssueJournalVoucher;
-        } else if (tx.thid_ < FLAGS_bomb_l1_thread_num
+        } else if (thid < FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num
                               + FLAGS_bomb_s2_thread_num
                               + FLAGS_bomb_s3_thread_num) {
           txType = TxType::AddNewProduct;
-        } else if (tx.thid_ < FLAGS_bomb_l1_thread_num
+        } else if (thid < FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num
                               + FLAGS_bomb_s2_thread_num
                               + FLAGS_bomb_s3_thread_num
@@ -467,7 +472,7 @@ public:
       }
 
       std::pair<TxType,timepoint> getRequest(TxExecutor& tx) {
-        if (tx.thid_ < FLAGS_bomb_l1_thread_num) {
+        if (static_cast<uint32_t>(tx.thid_) < FLAGS_bomb_l1_thread_num) {
           timepoint start = std::chrono::high_resolution_clock::now();;
           return make_pair(TxType::UpdateProductCostMaster, start);
         } else {
@@ -487,7 +492,7 @@ public:
 
       timepoint generate(BombWorkload* workload, TxExecutor& tx) {
         timepoint start;
-        if (tx.thid_ < FLAGS_bomb_l1_thread_num) {
+        if (static_cast<uint32_t>(tx.thid_) < FLAGS_bomb_l1_thread_num) {
           type = TxType::UpdateProductCostMaster;
           start = std::chrono::high_resolution_clock::now();
         } else if (!FLAGS_bomb_mixed_mode) {
@@ -1416,7 +1421,7 @@ RETRY:
       while (!loadAcquire(quit)) {
         for (int i = 0; i < numQueues; i++) {
           auto start = std::chrono::high_resolution_clock::now();
-          for (int j = 0; j < FLAGS_bomb_req_batch_size; j++) {
+          for (uint32_t j = 0; j < FLAGS_bomb_req_batch_size; j++) {
             requestQueues[i].push(make_pair(decideType(r, thresholds), start));
           }
           if (FLAGS_bomb_mixed_short_rate_tps) {

--- a/include/bomb_pessimistic.hh
+++ b/include/bomb_pessimistic.hh
@@ -334,7 +334,7 @@ public:
         rnd_.init();
 
         if (!FLAGS_bomb_mixed_mode) {
-          int total_threads = FLAGS_bomb_l1_thread_num
+          uint64_t total_threads = FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num
                               + FLAGS_bomb_s2_thread_num
                               + FLAGS_bomb_s3_thread_num
@@ -472,22 +472,27 @@ public:
       TxArgs args;
 
       TxType decideType(TxExecutor& tx, [[maybe_unused]] Xoroshiro128Plus& r) {
+        // tx.thid_ is a non-negative thread index whose underlying type varies
+        // between protocols (int / size_t / uint8_t / unsigned int). Cast it
+        // to uint32_t once so each comparison against FLAGS_bomb_*_thread_num
+        // (declared as uint32) is sign-clean.
+        const uint32_t thid = static_cast<uint32_t>(tx.thid_);
         TxType txType;
-        if (tx.thid_ < FLAGS_bomb_l1_thread_num) {
+        if (thid < FLAGS_bomb_l1_thread_num) {
           txType = TxType::UpdateProductCostMaster;
-        } else if (tx.thid_ < FLAGS_bomb_l1_thread_num
+        } else if (thid < FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num) {
           txType = TxType::UpdateMaterialCostMaster;
-        } else if (tx.thid_ < FLAGS_bomb_l1_thread_num
+        } else if (thid < FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num
                               + FLAGS_bomb_s2_thread_num) {
           txType = TxType::IssueJournalVoucher;
-        } else if (tx.thid_ < FLAGS_bomb_l1_thread_num
+        } else if (thid < FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num
                               + FLAGS_bomb_s2_thread_num
                               + FLAGS_bomb_s3_thread_num) {
           txType = TxType::AddNewProduct;
-        } else if (tx.thid_ < FLAGS_bomb_l1_thread_num
+        } else if (thid < FLAGS_bomb_l1_thread_num
                               + FLAGS_bomb_s1_thread_num
                               + FLAGS_bomb_s2_thread_num
                               + FLAGS_bomb_s3_thread_num
@@ -501,7 +506,7 @@ public:
       }
 
       std::pair<TxType,timepoint> getRequest(TxExecutor& tx) {
-        if (tx.thid_ < FLAGS_bomb_l1_thread_num) {
+        if (static_cast<uint32_t>(tx.thid_) < FLAGS_bomb_l1_thread_num) {
           timepoint start = std::chrono::high_resolution_clock::now();;
           return make_pair(TxType::UpdateProductCostMaster, start);
         } else {
@@ -521,7 +526,7 @@ public:
 
       timepoint generate(BombWorkload* workload, TxExecutor& tx) {
         timepoint start;
-        if (tx.thid_ < FLAGS_bomb_l1_thread_num) {
+        if (static_cast<uint32_t>(tx.thid_) < FLAGS_bomb_l1_thread_num) {
           type = TxType::UpdateProductCostMaster;
           start = std::chrono::high_resolution_clock::now();
         } else  if (!FLAGS_bomb_mixed_mode) {
@@ -1460,7 +1465,7 @@ RETRY:
       set_tx_name(TxType::ChangeProductQuantity, "ChangeProductQuantity");
 
       std::cout << "load factory" << std::endl;
-      for (int f_id = 1; f_id <= FLAGS_bomb_factory_size; f_id++) {
+      for (uint32_t f_id = 1; f_id <= FLAGS_bomb_factory_size; f_id++) {
         insert_factory(param, f_id);
       }
  
@@ -1475,7 +1480,7 @@ RETRY:
       for (auto &th : thv) th.join();
 
       std::cout << "load item master" << std::endl;
-      for (int i_id = 1; i_id <= ItemIdCounter; i_id++) {
+      for (uint32_t i_id = 1; i_id <= ItemIdCounter; i_id++) {
         insert_item_master(param, i_id);
       }
 
@@ -1540,7 +1545,7 @@ RETRY:
       while (!loadAcquire(quit)) {
         for (int i = 0; i < numQueues; i++) {
           auto start = std::chrono::high_resolution_clock::now();
-          for (int j = 0; j < FLAGS_bomb_req_batch_size; j++) {
+          for (uint32_t j = 0; j < FLAGS_bomb_req_batch_size; j++) {
             requestQueues[i].push(make_pair(decideType(r, thresholds), start));
           }
           if (FLAGS_bomb_mixed_short_rate_tps) {

--- a/include/masstree_wrapper.hh
+++ b/include/masstree_wrapper.hh
@@ -276,7 +276,8 @@ class MasstreeWrapper<T>::SearchRangeScanner {
   }
 
   bool visit_value(const Str key, T *val, threadinfo &) {
-    if (max_scan_num_ >= 0 && scan_buffer_->size() >= max_scan_num_) {
+    if (max_scan_num_ >= 0 &&
+        scan_buffer_->size() >= static_cast<std::size_t>(max_scan_num_)) {
       return false;
     }
 


### PR DESCRIPTION
[#43](https://github.com/thawk105/ccbench/issues/43) Phase 2 のサブタスク。`-Wsign-compare` を潰し、`ccbench_add_protocol()` に `-Werror=sign-compare` を追加する。

並列 subagent (background) が 4 commit + push まで実行、PR 作成段階で停止していたため、親エージェントが PR 作成 + CI watch を引き継いだ。

## 修正

subagent が小刻みに commit してくれているのでファイル単位:

| commit | 内容 |
|---|---|
| `9ef4f9c` | `Phase 2: enable -Werror=sign-compare (cmake side)` |
| `03a76e8` | `Phase 2: fix sign-compare in include/bomb.hh` |
| `f0397aa` | `Phase 2: fix sign-compare in include/bomb_pessimistic.hh` |
| `43852ca` | `Phase 2: fix sign-compare in masstree_wrapper.hh and cc/oze/util.cc` |

## 修正パターン

`-Wsign-compare` の典型 (signed vs `size_t` / `unsigned` の比較) を各箇所で:

- `int i; for(i=0; i<container.size(); ++i)` 系のループ counter → 容量を表す側に合わせて修正
- `int` ↔ `google::uint32` / `google::uint64` の比較 → cast or 型変更
- `std::vector::size_type` ↔ `int64_t` の比較 (masstree_wrapper の scan limit 周り)

## CMake

```diff
 target_compile_options(${target} PRIVATE
   -Werror=maybe-uninitialized
   -Werror=unused-but-set-variable
   -Werror=unused-label
   -Werror=reorder
   -Werror=unused-parameter
   -Werror=catch-value
-  -Werror=unused-variable)
+  -Werror=unused-variable
+  -Werror=sign-compare)
```

## Subagent prompt 改善のメモ

前回 (1 回目) は context window 枯渇で死亡、進捗ゼロだった。今回 (再投入) は改良 prompt:
- build 出力は `tee /tmp/build.log >/dev/null` 経由で抜粋のみ取得
- `-j4` 固定
- **小刻みに commit** (cmake → 各ソース) ← この PR が示す通り、subagent が PR 作成段階で死んでも 4 commit + push は残った
- 結果として「PR 作成だけ親が引き取る」最小コストで完走

詳細な学習は親エージェントの memory に保存済み。

## Test plan

- [x] **subagent** が GCC 13 Release / `-DENABLE_SANITIZER=OFF` で 34/34 確認 (subagent レポートより)
- [x] **subagent** が GCC 11 Debug + ASan で 34/34 確認
- [ ] CI 緑

## Related

- #43 Phase 2 (parallel work)
- 並列の sister PR: #68 (`-Wignored-qualifiers`、merged 待ち)