### PR TITLE
cmake: dead な find_package(Doxygen) を削除

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CCBENCH_CCACHE)
   endif()
 endif()
 
-find_package(Doxygen)
 find_package(Threads REQUIRED)
 find_package(gflags REQUIRED)
 find_package(glog REQUIRED)


### PR DESCRIPTION
## 概要

トップレベル `CMakeLists.txt` の `find_package(Doxygen)` は完全な dead call。
`DOXYGEN_FOUND` / `doxygen_add_docs()` / `DOXYFILE` の利用箇所がリポジトリ内に 0 件で、
configure 時に無駄な `Could NOT find Doxygen` の status 行を出すだけになっていた。
この 1 行を削除する。

Closes #62

## 変更内容

- `CMakeLists.txt` から `find_package(Doxygen)` の行を削除。
- 前後の `find_package(Threads REQUIRED)` 等はそのまま残置。

## テスト

- `cmake -B /tmp/build-62 -DCMAKE_BUILD_TYPE=Release .` が緑 (`Configuring done` / `Generating done`)。
- configure 出力から Doxygen 関連の status 行 (`Could NOT find Doxygen`) が消えたことを grep で確認。