### PR TITLE
third_party: 未使用の spdlog submodule を除去 (#64 の一部)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "third_party/mimalloc"]
 	path = third_party/mimalloc
 	url = https://github.com/microsoft/mimalloc.git
-[submodule "third_party/spdlog"]
-	path = third_party/spdlog
-	url = https://github.com/gabime/spdlog.git


### PR DESCRIPTION
## 概要

issue #64 (third_party を FetchContent に移行) の To-do の最初の項目「\`third_party/spdlog\` submodule の利用調査 → 未使用なら submodule から外す」だけを切り出した PR です。**#64 全体ではなく spdlog の件のみ**。

## 調査結果: spdlog 参照は実質 0 件

issue 本文指定の grep と、CMake / build_tools / CI / Dockerfile まで広げた grep を実施:

\`\`\`
$ grep -rn 'spdlog' include/ cc/ common/
include/logger.h:13:#include "spdlog/spdlog.h"
include/logger.h:17:static inline void setup_spdlog() {
include/logger.h:20:    spdlog::set_level(spdlog::level::info);
include/logger.h:22:    spdlog::set_level(spdlog::level::debug);
\`\`\`

spdlog を参照しているのは \`include/logger.h\` のみ。さらに調べると:

- \`include/logger.h\` を \`#include\` しているファイルは**ゼロ** (どこからも include されていない)
- \`setup_spdlog()\` の呼び出し元も**ゼロ**
- CMakeLists.txt / \*.cmake は spdlog にも logger にも一切触れていない (\`add_subdirectory\` も include path 追加もなし)
- \`build_tools/\` に \`bootstrap_spdlog.sh\` 相当は存在しない (googletest / mimalloc / tbb のみ)
- CI / Dockerfile にも参照なし
- \`third_party/spdlog\` submodule はそもそも init されていなかった

つまり spdlog はビルドにまったく組み込まれておらず、唯一の参照元 \`include/logger.h\` 自体が orphan な dead code です。submodule として保持する理由がないため除去します。

## 変更内容

- \`.gitmodules\` から \`third_party/spdlog\` セクションを削除
- \`third_party/spdlog\` の gitlink を削除

CMake / build_tools / CI / Dockerfile への参照は 0 件だったため、それらの変更はありません。

なお \`include/logger.h\` (どこからも使われていない dead code) と \`docs/architecture_{ja,en}.md\` の submodule 一覧記述は、本 PR のスコープ (submodule 除去) を超えるためあえて触れていません。別途整理対象です。

## test plan

- \`cmake -B /tmp/build-spdlog -DCMAKE_BUILD_TYPE=Release .\` → configure 緑 (Configuring done / Generating done)

## 関連

#64 の一部 (#64 自体は close しません)