### PR TITLE
P4: ss2pl/test の add_definitions を target_compile_definitions 化 (#60)

### DIFF
--- a/cc/ss2pl/test/CMakeLists.txt
+++ b/cc/ss2pl/test/CMakeLists.txt
@@ -10,49 +10,23 @@ file (GLOB TEST_SOURCES
 "make_db_test.cpp"
 )
 
-if (DEFINED ADD_ANALYSIS)
-    add_definitions(-DADD_ANALYSIS=${ADD_ANALYSIS})
-else ()
-    add_definitions(-DADD_ANALYSIS=0)
-endif ()
-
-if (DEFINED BACK_OFF)
-    add_definitions(-DBACK_OFF=${BACK_OFF})
-else ()
-    add_definitions(-DBACK_OFF=0)
-endif ()
-
-add_definitions(-DDLR1)
-
-if (DEFINED KEY_SIZE)
-    add_definitions(-DKEY_SIZE=${KEY_SIZE})
-else ()
-    add_definitions(-DKEY_SIZE=8)
-endif ()
-
-if (DEFINED KEY_SORT)
-    add_definitions(-DKEY_SORT=${KEY_SORT})
-else ()
-    add_definitions(-DKEY_SORT=0)
-endif ()
-
-if (DEFINED MASSTREE_USE)
-    add_definitions(-DMASSTREE_USE=${MASSTREE_USE})
-else ()
-    add_definitions(-DMASSTREE_USE=1)
-endif ()
-
-if (DEFINED VAL_SIZE)
-    add_definitions(-DVAL_SIZE=${VAL_SIZE})
-else ()
-    add_definitions(-DVAL_SIZE=4)
-endif ()
+# Build-time flags. The universal `-D` set comes from cmake/Options.cmake so
+# the test target uses the same flags as the ss2pl protocol body; DLR1 and
+# KEY_SORT are ss2pl-specific (mirrors cc/ss2pl/CMakeLists.txt).
+ccbench_universal_definitions(SS2PL_TEST_DEFINITIONS)
 
 foreach(src IN LISTS TEST_SOURCES)
     get_filename_component(fname "${src}" NAME_WE)
     set(test_name "${fname}")
 
     add_executable(${test_name} ${src} ${SS2PL_SOURCES})
+
+    target_compile_definitions(${test_name}
+            PRIVATE
+            ${SS2PL_TEST_DEFINITIONS}
+            DLR1
+            KEY_SORT=${CCBENCH_KEY_SORT}
+    )
 
     target_include_directories(${test_name}
             PRIVATE ${PROJECT_SOURCE_DIR}/../third_party/googletest/googletest/include


### PR DESCRIPTION
## 概要

`cc/ss2pl/test/CMakeLists.txt` に残っていた古いスタイルのディレクトリスコープ `add_definitions(...)` 13 件を、target スコープの `target_compile_definitions(<target> PRIVATE ...)` に書き換えた。

Closes #60

## 変更内容

- universal な `-D` フラグ (`ADD_ANALYSIS` / `BACK_OFF` / `KEY_SIZE` / `MASSTREE_USE` / `VAL_SIZE`) は `cmake/Options.cmake` の `ccbench_universal_definitions()` ヘルパーで集約。本体プロトコル (`cc/silo/CMakeLists.txt` の `replay_test.exe` 等) と同じ universal flag を共有する。
- ss2pl 固有の `DLR1` と `KEY_SORT` は `cc/ss2pl/CMakeLists.txt` の `ccbench_add_protocol(...)` の `OPTIONS` に合わせ、`target_compile_definitions` で個別に付与 (`KEY_SORT=${CCBENCH_KEY_SORT}`)。
- `if (DEFINED ...)` の手書きデフォルト分岐は `cmake/Options.cmake` の CACHE 変数にデフォルトが集約されているため不要になり削除。
- `third_party/` 配下の `add_definitions` は外部 submodule のため touch していない。

## test plan

- `cmake -B build -DCMAKE_BUILD_TYPE=Release .` : configure 緑。
- `cc/ss2pl/test/CMakeLists.txt` を単体 configure するスタンドアロンハーネスで `make_db_test` をビルド確認。`target_compile_definitions` が target-private flag として正しく適用されること (`-DADD_ANALYSIS=0 -DBACK_OFF=1 -DDLR1 -DKEY_SIZE=8 -DKEY_SORT=0 -DMASSTREE_USE=1 -DVAL_SIZE=4`) を `flags.make` で確認。
- `grep -rn 'add_definitions' --include='CMakeLists.txt' --include='*.cmake' .` : プロジェクト本体の `add_definitions()` 呼び出しは 0 件 (ヒットするのは `cmake/Options.cmake` / `cmake/ProtocolHelpers.cmake` のコメント文のみ、`third_party/` は対象外)。

## 補足 (#60 のスコープ外)

`cc/ss2pl/test/` は #32 のリファクタ以降どの `add_subdirectory` からも参照されておらず、現状ビルドツリーに組み込まれていない。また `make_db_test.cpp` の `#include "../../include/common.hh"` は階層がずれた stale path になっている。いずれも本 issue (#60: `add_definitions` の近代化) のスコープ外のため本 PR では触れていない。