### PR TITLE
docs/coding-conventions: commit 前に clang-format を当てる規約を追加

### DIFF
--- a/docs/coding-conventions_en.md
+++ b/docs/coding-conventions_en.md
@@ -85,6 +85,23 @@ This was actually missing in `get_material_cost()` and was surfaced by
 `-Werror=unused-variable` in PR #58 — be aware of it on both the reading
 and writing side, before review has to flag it.
 
+## clang-format
+
+- **Before committing, format the C++ sources (`.cc` / `.hh` / `.cpp`) you
+  changed with `clang-format`**. The config is [.clang-format](../.clang-format)
+  at the repository root. Doing it locally cuts down round-trips with the CI
+  check below (#63).
+- **Prefer `git clang-format` to format only the staged diff**.
+  `clang-format -i <file>` reformats the whole file, so touching a
+  not-yet-formatted file drags in a large unrelated diff (the repository-wide
+  bulk reformat is in progress in #74 — until that merges, use
+  `git clang-format` in particular).
+- **Keep large reformats in a separate commit / PR** from the actual change,
+  so formatting noise doesn't bury the substantive diff.
+- Adding a format check to CI is tracked in #63. Once CI is green, format
+  violations can't slip through to merge; until then, applying it locally
+  before push is the safeguard.
+
 ## Shell scripts
 
 - **`set -euo pipefail`** at the top (early failure + detect unset

--- a/docs/coding-conventions_ja.md
+++ b/docs/coding-conventions_ja.md
@@ -74,6 +74,23 @@ if (stat != Status::OK) return false;   // do not skip this
 `-Werror=unused-variable` で表面化したことがある — レビューで指摘する前に
 ここを読む / 書く側で意識する。
 
+## clang-format
+
+- **commit する前に、変更した C++ ソース (`.cc` / `.hh` / `.cpp`) を
+  `clang-format` で整形する**。設定はリポジトリ直下の
+  [.clang-format](../.clang-format)。手元で揃えておけば、後述の CI チェック
+  (#63) との往復が減る。
+- **基本は `git clang-format` で staged 差分の範囲だけ整形する**。
+  `clang-format -i <file>` はファイル全体を整形してしまうため、まだ
+  format が揃っていないファイルを触ると無関係な大量差分が混ざる
+  (コードベース全体の一括 reformat は #74 で対応中 — それが merge される
+  までは特に `git clang-format` を使うこと)。
+- **大規模な reformat は本来の変更と別 commit / 別 PR にする**。整形差分に
+  本質的な変更が埋もれてレビュー性が落ちるのを防ぐ。
+- format チェックを CI に入れる作業は #63 で追跡している。CI が緑になれば
+  「format 違反のまま merge される」ことはなくなるが、それまでは push 前に
+  手元で当てる運用で防ぐ。
+
 ## Shell スクリプト
 
 - **`set -euo pipefail`** を冒頭に置く (早期失敗 + 未定義変数の検出 + パイプ


### PR DESCRIPTION
## 概要

変更した C++ ソース (`.cc` / `.hh` / `.cpp`) は commit 前に `clang-format` で整形する、という規約を `docs/coding-conventions_{ja,en}.md` に追加する。

「commit/push 前に clang-format を当てる」運用について、自動強制 (hook) は入れず **ドキュメントに規約として明記する**方針を採った。自動チェックは CI 側 (#63) に委ねる。

## 追加した内容

`## clang-format` 節を C++ 節の直後に新設:

- commit 前に、変更した C++ ソースを `clang-format` で整形する
- **基本は `git clang-format` で staged 差分の範囲だけ整形する** — コードベース全体がまだ未整形 (一括 reformat は #74 で対応中) なので、ファイル全体を整形する `clang-format -i` は無関係な大量差分を巻き込む
- 大規模 reformat は本来の変更と別 commit / 別 PR にする
- CI への format チェック追加は #63 で追跡

## 補足: 関連する進行中の作業

- #75 — `.clang-format` 自体のリファイン (OPEN)
- #74 / #76 — コードベース全体の一括 reformat (#76 は #75 にスタック、OPEN)
- #63 — CI に clang-format チェックジョブを追加 (OPEN)

この PR はそれらと独立してドキュメント規約だけを足すもの。

## Test plan

- ドキュメントのみの変更。`docs/coding-conventions_ja.md` (原典) と `docs/coding-conventions_en.md` (翻訳) を同一 commit で更新済み (CLAUDE.md ハードルール準拠)。