### PR TITLE
ci: clang-format dry-run チェックジョブを追加 (#63)

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,55 @@
+name: format
+
+on:
+  push:
+    # Keep paths-ignore in sync with build.yml: a docs-only or
+    # devcontainer-only change should not spin up CI.
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '.devcontainer/**'
+      - '.github/workflows/devcontainer-image.yml'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '.devcontainer/**'
+      - '.github/workflows/devcontainer-image.yml'
+
+jobs:
+  # Independent of build.yml's `build` job on purpose: a formatting
+  # violation and a compile break are unrelated failures, and seeing
+  # one job red while the other stays green pinpoints which it is.
+  format-check:
+    runs-on: ubuntu-latest
+    # clang-format only ships in the `dev` stage of .devcontainer/Dockerfile
+    # (published as :latest) — the slim :ci image used by build.yml has it
+    # stripped. Use :latest here rather than fattening :ci, which would mean
+    # a Dockerfile change + image rebuild for no other gain.
+    #
+    # --user root: same reason as build.yml — the GHA runner's bind-mounted
+    # work dir is host-owned, so actions' housekeeping writes need root.
+    container:
+      image: ghcr.io/thawk105/ccbench-devcontainer:latest
+      options: --user root
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Later steps run git from a fresh `sh -e {0}` shell where
+      # checkout's scoped safe.directory is not always picked up; set it
+      # globally so `git ls-files` below sees the workspace as safe.
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      # Same target set as the bulk reformat (PR #76): all *.cc / *.hh /
+      # *.cpp tracked under cc/, include/ and common/. There are no
+      # third_party/ or build/ trees nested under those, so the extension
+      # filter alone is enough; --Werror makes any diff fail the job.
+      - name: clang-format dry-run
+        run: |
+          clang-format --version
+          git ls-files -- cc include common \
+            | grep -E '\.(cc|hh|cpp)$' \
+            | xargs clang-format --dry-run --Werror


### PR DESCRIPTION
## 概要

CI に build とは独立した軽量な clang-format チェックジョブを追加する。
`clang-format --dry-run --Werror` で `.clang-format` に違反するファイルを
検出し、フォーマット崩れのコミットが master に混入するのを防ぐ。

`Closes #63`

## スタック構成 (重要)

このPRは以下のスタックの最上段で、**#75・#76 が先にマージされる必要がある**。

```
master ← #75 (refine-clang-format) ← #76 (bulk-clang-format-reformat) ← このPR
```

理由: 現在の master のソースは未整形なので、clang-format チェックを足すと
即 CI が赤になる。#75 でリファインした `.clang-format`、#76 でコードベース
全体を reformat 済みのツリーの上にこのジョブを足すことで、初めて緑になる。
GitHub 上の diff も #76 マージ後は format.yml の追加 1ファイルだけになる。

## 実装方針

### Option 1 / Option 2 → Option 2 を選択

新規ワークフロー `.github/workflows/format.yml` として分離した
(issue 本文の Option 2)。理由:

- build と format は無関係な失敗 (コンパイル破壊 / フォーマット崩れ)。
  ジョブを分けておけば、どちらが赤かが Actions 一覧で一目で分かる。
- `paths-ignore` は `build.yml` と完全に揃えてあり、docs 等の変更で
  無駄に走らない点は Option 1 と同じ。

### clang-format を動かす image → `:latest` を選択

`.devcontainer/Dockerfile` を確認したところ、`clang-format` は `dev`
stage (= `:latest`) にのみ入っており、`build.yml` が使う slim な `:ci`
image には入っていない (#46 で slim 化)。`:ci` に `clang-format` を足すと
Dockerfile 変更 + image 再ビルドが必要でスコープが膨らむため、format-check
ジョブだけ `:latest` を使う。`build.yml` と同様に container job なので
`--user root` + `git config --global --add safe.directory` を設定。

## 検証

#76 のツリー (このPRの作業ツリー) 上で、ワークフローが実行するのと同じ
コマンドをローカル実行し緑を確認:

```
$ clang-format --version
Ubuntu clang-format version 14.0.0-1ubuntu1.1
$ git ls-files -- cc include common | grep -E '\.(cc|hh|cpp)$' | xargs clang-format --dry-run --Werror
$ echo $?
0
```

- 対象は `cc/ include/ common/` 配下の `.cc/.hh/.cpp` 計 240 ファイル。
  #76 が reformat した集合と一致。`cc/include/common` 配下に `third_party/`
  や `build/` のツリーは無いため、拡張子フィルタだけで十分。
- clang-format のバージョンは 14 で #75/#76 および CI image (`:latest`、
  ubuntu:24.04 ベース) と一致。

「master 上で緑」の最終確認は、スタック (#75 → #76 → このPR) が全部
マージされた後になる。

## actions / 規約

- `actions/checkout@v6` をメジャー版 pin (`build.yml` に合わせる)。
- `paths-ignore` を `build.yml` と同期。
- container job の `--user root` + `safe.directory` 設定済み。