### PR TITLE
masstree: remove_value_if_present() を追加し DELETE-commit パスで使用 (#59)

### DIFF
--- a/cc/d2pl/transaction.cc
+++ b/cc/d2pl/transaction.cc
@@ -85,7 +85,7 @@ bool TxExecutor::commit() {
       case OpType::DELETE: {
         // Return value intentionally ignored: a missing key still needs the
         // record put on the GC queue below.
-        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
+        Masstrees[get_storage((*itr).storage_)].remove_value_if_present((*itr).key_);
         // create information for garbage collection
         gc_records_.push_back((*itr).rcdptr_);
         break;

--- a/cc/mocc/transaction.cc
+++ b/cc/mocc/transaction.cc
@@ -958,7 +958,7 @@ void TxExecutor::abort() {
   // remove inserted records
   for (auto& we : write_set_) {
     if (we.op_ == OpType::INSERT) {
-      Masstrees[get_storage(we.storage_)].remove_value(we.key_);
+      Masstrees[get_storage(we.storage_)].remove_value_if_present(we.key_);
       delete we.rcdptr_;
     }
   }
@@ -1047,7 +1047,7 @@ void TxExecutor::writePhase() {
         maxtid.absent = true;
         // Return value intentionally ignored: a missing key still needs the
         // record put on the GC queue below.
-        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
+        Masstrees[get_storage((*itr).storage_)].remove_value_if_present((*itr).key_);
         gc_records_.push_back((*itr).rcdptr_);
         break;
       }

--- a/cc/silo/transaction.cc
+++ b/cc/silo/transaction.cc
@@ -27,7 +27,7 @@ void TxExecutor::abort() {
   // remove inserted records
   for (auto& we : write_set_) {
     if (we.op_ == OpType::INSERT) {
-      Masstrees[get_storage(we.storage_)].remove_value(we.key_);
+      Masstrees[get_storage(we.storage_)].remove_value_if_present(we.key_);
       delete we.rcdptr_;
     }
   }
@@ -554,7 +554,7 @@ void TxExecutor::writePhase() {
         maxtid.absent = true;
         // Return value intentionally ignored: a missing key still needs the
         // tid bump and gc_records_ push below.
-        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
+        Masstrees[get_storage((*itr).storage_)].remove_value_if_present((*itr).key_);
         storeRelease((*itr).rcdptr_->tidword_.obj_, maxtid.obj_);
         // create information for garbage collection
         gc_records_.push_back((*itr).rcdptr_);

--- a/cc/ss2pl/transaction.cc
+++ b/cc/ss2pl/transaction.cc
@@ -85,7 +85,7 @@ bool TxExecutor::commit() {
       case OpType::DELETE: {
         // Return value intentionally ignored: a missing key still needs the
         // record put on the GC queue below.
-        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
+        Masstrees[get_storage((*itr).storage_)].remove_value_if_present((*itr).key_);
         // create information for garbage collection
         gc_records_.push_back((*itr).rcdptr_);
         break;

--- a/cc/tictoc/transaction.cc
+++ b/cc/tictoc/transaction.cc
@@ -477,7 +477,7 @@ void TxExecutor::abort() {
   // remove inserted records
   for (auto& we : write_set_) {
     if (we.op_ == OpType::INSERT) {
-      Masstrees[get_storage(we.storage_)].remove_value(we.key_);
+      Masstrees[get_storage(we.storage_)].remove_value_if_present(we.key_);
       delete we.rcdptr_;
     }
   }
@@ -526,7 +526,7 @@ void TxExecutor::writePhase() {
         result.absent = true;
         // Return value intentionally ignored: a missing key still needs the
         // record put on the GC queue below.
-        (void)Masstrees[get_storage((*itr).storage_)].remove_value((*itr).key_);
+        Masstrees[get_storage((*itr).storage_)].remove_value_if_present((*itr).key_);
         gc_records_.emplace_back((*itr).storage_, (*itr).key_, (*itr).rcdptr_, ThLocalEpoch[thid_].obj_);
         break;
       }

--- a/include/masstree_wrapper.hh
+++ b/include/masstree_wrapper.hh
@@ -165,6 +165,12 @@ public:
     return Status::WARN_NOT_FOUND;
   }
 
+  // "delete if present" — discards "not found" since callers in the
+  // DELETE-commit path may race with concurrent deletions of the same key.
+  void remove_value_if_present(std::string_view key) {
+    (void) remove_value(key);
+  }
+
   T *get_value(std::string_view key) {
     unlocked_cursor_type lp(table_, key.data(), key.size());
     bool found = lp.find_unlocked(*ti);


### PR DESCRIPTION
Closes #59

## 変更内容

`MasstreeWrapper` に戻り値 void の「あれば消す」wrapper `remove_value_if_present(std::string_view)` を追加し、DELETE-commit 文脈で `Status` を捨てている 8 callsite (5 protocol) を置き換えた。

### wrapper 追加

`include/masstree_wrapper.hh` — `remove_value()` を `(void)` で呼ぶだけの薄い wrapper。`(void)` キャストの boilerplate を消し、「Status を意図的に捨てている」というシグナルを呼び出し側に与える。

```cpp
// "delete if present" — discards "not found" since callers in the
// DELETE-commit path may race with concurrent deletions of the same key.
void remove_value_if_present(std::string_view key) {
  (void) remove_value(key);
}
```

### 置き換えた callsite (8 箇所 / 5 protocol)

| Protocol | Callsite |
|---|---|
| silo | cc/silo/transaction.cc:30, cc/silo/transaction.cc:557 |
| mocc | cc/mocc/transaction.cc:961, cc/mocc/transaction.cc:1050 |
| tictoc | cc/tictoc/transaction.cc:480, cc/tictoc/transaction.cc:529 |
| ss2pl | cc/ss2pl/transaction.cc:88 |
| d2pl | cc/d2pl/transaction.cc:88 |

`(void)...remove_value(...)` だった 5 箇所、および元々戻り値レスで `...remove_value(...)` を呼んでいた 3 箇所を、すべて `...remove_value_if_present(...)` に統一。`MasstreeWrapper` 側 + callsite 置き換えのみで、protocol-specific なロックタイミング・GC キュー push 順序には一切触れていない。DELETE-commit 文脈でない `remove_value` 呼び出し (Status を実際に使うもの) は変更なし。

## Test plan

GCC 13 (CI と同じコンパイラ) で全バイナリをフルビルド。5 protocol 含め全 target 緑 (exit 0)。

- Release (`-DCMAKE_BUILD_TYPE=Release -DENABLE_SANITIZER=OFF`): OK
- Debug + ASan (`-DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZER=ON`): OK