### PR TITLE
Phase 5: set_compile_options() で -Wall -Wextra -Werror を有効化 (#43)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project(ccbench LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+# set_compile_options() — applied to ccbench_common here and to every
+# protocol binary via ccbench_add_protocol() (see cmake/CompileOptions.cmake).
+include(CompileOptions)
+
 set(THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party/")
 
 option(ENABLE_SANITIZER "enable sanitizer on debug build" ON)
@@ -51,6 +55,7 @@ add_library(ccbench_common STATIC
   common/util.cc
 )
 target_compile_features(ccbench_common PUBLIC cxx_std_20)
+set_compile_options(ccbench_common)
 target_include_directories(ccbench_common PUBLIC
   ${CMAKE_SOURCE_DIR}
 )

--- a/cc/silo/CMakeLists.txt
+++ b/cc/silo/CMakeLists.txt
@@ -20,3 +20,5 @@ add_executable(replay_test.exe replayTest.cc)
 target_link_libraries(replay_test.exe PRIVATE
   ccbench_common ccbench::masstree ccbench::mimalloc)
 target_compile_definitions(replay_test.exe PRIVATE ${_universal_defs})
+# Same -Wall -Wextra -Werror as the ccbench_add_protocol() binaries (#43).
+set_compile_options(replay_test.exe)

--- a/cc/silo/include/log.hh
+++ b/cc/silo/include/log.hh
@@ -30,13 +30,16 @@ public:
 
   // computeChkSum() below sums every int-sized chunk of *this*, including
   // any trailing struct padding after val_, so both constructors zero
-  // the entire object first to make those reads well-defined.
+  // the entire object first to make those reads well-defined. The memset
+  // goes through a void* because LogRecord is non-trivial (it holds a
+  // std::string_view) — clearing it as raw bytes is intentional here and
+  // -Wclass-memaccess would otherwise flag the typed pointer.
   LogRecord() {
-    memset(this, 0, sizeof(LogRecord));
+    memset(static_cast<void *>(this), 0, sizeof(LogRecord));
   }
 
   LogRecord(uint64_t tid, std::string_view key, char *val) {
-    memset(this, 0, sizeof(LogRecord));
+    memset(static_cast<void *>(this), 0, sizeof(LogRecord));
     tid_ = tid;
     key_ = key;
     memcpy(this->val_, val, VAL_SIZE);

--- a/cmake/ProtocolHelpers.cmake
+++ b/cmake/ProtocolHelpers.cmake
@@ -42,21 +42,11 @@ function(ccbench_add_protocol name)
       ${_universal_defs}
       ${_extra_defs})
 
-    # Phased -Werror cleanup (see #43). The full -Wall -Wextra -Werror via
-    # set_compile_options() is still gated on Phase 5 — we promote one
-    # warning class to error at a time as the existing offenders get
-    # fixed. Append the next entry here when its source-level cleanup
-    # PR lands.
-    target_compile_options(${target} PRIVATE
-      -Werror=maybe-uninitialized
-      -Werror=unused-but-set-variable
-      -Werror=unused-label
-      -Werror=reorder
-      -Werror=unused-parameter
-      -Werror=catch-value
-      -Werror=unused-variable
-      -Werror=ignored-qualifiers
-      -Werror=sign-compare)
+    # Phased -Werror cleanup complete (see #43). Phases 1-4 promoted nine
+    # individual -Werror=<flag> classes one at a time as the existing
+    # offenders got fixed; Phase 5 replaces that list with the full
+    # -Wall -Wextra -Werror via set_compile_options().
+    set_compile_options(${target})
 
     set_property(TARGET ${target} PROPERTY CCBENCH_PROTOCOL "${name}")
     set_property(TARGET ${target} PROPERTY CCBENCH_WORKLOAD "${wl}")

--- a/common/result.cc
+++ b/common/result.cc
@@ -544,7 +544,9 @@ void Result::addLocalForwarding1Count(const uint64_t count) { total_forwarding1_
 void Result::addLocalForwarding2Count(const uint64_t count) { total_forwarding1_count_ += count; }
 #endif
 
-void Result::displayOzeAnalysisResult(size_t clocks_per_us, size_t extime, size_t thread_num) {
+void Result::displayOzeAnalysisResult([[maybe_unused]] size_t clocks_per_us,
+                                      [[maybe_unused]] size_t extime,
+                                      [[maybe_unused]] size_t thread_num) {
   // only for oze
 #if ADD_ANALYSIS
   displayReadValidationRate(clocks_per_us, extime, thread_num);

--- a/include/tpcc/tpcc_util.hh
+++ b/include/tpcc/tpcc_util.hh
@@ -47,6 +47,18 @@ inline void fill_random(void* out, size_t size)
 {
   char* p = reinterpret_cast<char*>(out);
 
+  // The word-at-a-time loop only runs while `size >= 8`, so each 8-byte
+  // memcpy stays within `out`; the tail handles the remaining `size % 8`.
+  // GCC 13's interprocedural -Wstringop-overflow still flags the loop
+  // body when this is inlined into random_string_detail() for the
+  // 51-byte I_DATA / S_DATA buffers, because it cannot bound the
+  // random_int()-derived length tightly enough. The callers always pass
+  // a buffer of `max_len + 1`, so this is a false positive — suppress it
+  // locally rather than pessimizing the hot init path.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
   uint64_t buf;
   while (size >= sizeof(uint64_t)) {
     buf = random_64bits();
@@ -58,6 +70,9 @@ inline void fill_random(void* out, size_t size)
     buf = random_64bits();
     ::memcpy(p, &buf, size);
   }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 


### PR DESCRIPTION
## 概要

issue #43 の段階的 -Werror 化、最終フェーズ (Phase 5 = 仕上げ)。Phase 1〜4 で 9 個の `-Werror=<flag>` クラスを 1 つずつ潰してきたが、Phase 5 ではその明示リストを `set_compile_options()` (= `-Wall -Wextra -Werror`) に置き換える。

## cmake 変更

- **`cmake/ProtocolHelpers.cmake`**: `ccbench_add_protocol()` 内の `target_compile_options(... -Werror=... )` 9 個の列を `set_compile_options(${target})` 呼び出しに置き換え。
- **`CMakeLists.txt`**: `set_compile_options()` を使えるよう `include(CompileOptions)` を冒頭に hoist し、`ccbench_common` ターゲットにも適用。
- **`cc/silo/CMakeLists.txt`**: スタンドアロンの `replay_test.exe` にも適用。

`set_compile_options()` が有効化するのは `-Wall -Wextra -Werror` の 3 つだけ (`cmake/CompileOptions.cmake`)。`-Wpedantic` / `-Wshadow` / `-Wconversion` 等は含まない。

## 新規 warning と対処

`-Wall -Wextra` を `ccbench_common` と全プロトコルバイナリに適用したことで、Phase 1〜4 で潰した 9 クラス以外に 3 クラスが表面化した。いずれも小規模・機械的なので本 PR 内で対処:

| ファイル | warning | 対処 |
|---|---|---|
| `common/result.cc` | `-Wunused-parameter` (3 件) | `displayOzeAnalysisResult()` の引数は `#if ADD_ANALYSIS` 時のみ使用 → 直下の `displayAllResult()` と同じく `[[maybe_unused]]` を付与 |
| `cc/silo/include/log.hh` | `-Wclass-memaccess` (2 箇所) | `LogRecord` は `std::string_view` を持つ非 trivial 型。`computeChkSum()` のため padding 含め全バイトゼロ化する意図は正しいので、`memset` を `static_cast<void *>(this)` 経由に変更 |
| `include/tpcc/tpcc_util.hh` | `-Wstringop-overflow` (26 件) | GCC 13 が `fill_random()` を `random_string_detail()` にインライン展開した際の interprocedural な誤検知。ループは `size >= 8` の間しか回らず、呼び出し側は常に `max_len + 1` バイトのバッファを渡すため overflow しない。ホットな init パスを悪化させず、説明コメント付きで局所的に suppress |

## test plan

GCC 13 (= CI と同じコンパイラ) でクリーンフルビルド:

```
cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_SANITIZER=OFF \
  -DCMAKE_CXX_COMPILER=g++-13 -DCMAKE_C_COMPILER=gcc-13 .
cmake --build build -j4
```

結果: **exit 0 / warning 0 / error 0**。全 34 プロトコルバイナリ + `ccbench_common` + `replay_test.exe` がビルド成功。

Closes #43