### PR TITLE
ci: devcontainer の clang-format を 14 に固定 (PR #78 の CI 失敗修正)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@
 # Two stages published as two tags:
 #   - `base` -> :ci    (minimal — what CI's build.yml actually needs)
 #   - `dev`  -> :latest (`base` + human-facing tools used in the
-#                       devcontainer: zsh shell, clang-format, sudo,
+#                       devcontainer: zsh shell, clang-format-14, sudo,
 #                       openssh-client, curl)
 #
 # Keeping the CI image slim means container init in GitHub Actions
@@ -69,16 +69,24 @@ FROM base AS dev
 
 ARG USERNAME=vscode
 
+# clang-format is pinned to the major version the repo was reformatted with
+# (PR #75/#76 used clang-format 14). The unversioned `clang-format` meta
+# package on Ubuntu 24.04 points at 18, whose output diverges from 14 — that
+# mismatch would make the format.yml dry-run job fail on an already-formatted
+# tree. update-alternatives restores the plain `clang-format` name so the
+# workflow (and humans) can call it without the version suffix.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        clang-format \
+        clang-format-14 \
         curl \
         htop \
         openssh-client \
         sudo \
         zsh \
+    && update-alternatives --install /usr/bin/clang-format clang-format \
+        /usr/bin/clang-format-14 100 \
     && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/${USERNAME} \
     && chmod 0440 /etc/sudoers.d/${USERNAME}
 


### PR DESCRIPTION
## 背景

PR #78 (issue #63 — CI に clang-format dry-run チェックを追加) が追加する
`.github/workflows/format.yml` の `format-check` ジョブが、**整形済みの
ツリーに対して失敗**していた。

## 根本原因 (CI 失敗ログから判明した事実)

clang-format の**メジャーバージョン不一致**。

- PR #75/#76 はローカルの **clang-format 14** で `.clang-format` のリファインと
  全ソースの一括 reformat を実施した。
- 一方 `.devcontainer/Dockerfile` の `dev` ステージは
  `apt-get install clang-format` と**バージョン無指定**でインストールしており、
  Ubuntu 24.04 のデフォルトである **clang-format 18** が入る。
  `format.yml` はこの `:latest` image 上で走る。

#78 の失敗 run のログ冒頭にも `Ubuntu clang-format version 18.1.3` と出力され、
その直後から `cc/cicada/...` 等で `code should be clang-formatted` の violation が
多数並んでいた。14 で整形したツリーに 18 の `--dry-run --Werror` を当てれば
整形ルールの差で必ず diff が出るため、ジョブは緑になりようがない状態だった。

## 修正内容

`.devcontainer/Dockerfile` の `dev` ステージのインストールを
`clang-format` → `clang-format-14` の明示指定に変更し、
`update-alternatives` で plain な `clang-format` 名を `clang-format-14` に
張り直す（`format.yml` も人間もバージョンサフィックス無しで呼べるように）。

これで「reformat に使った版」と「CI が使う版」のメジャーが 14 で一致する。
`clang-format-14` は Ubuntu 24.04 noble の universe に
`1:14.0.6-19build4` として存在する。

## #75 / #76 / #78 のスタックとの関係

スタック構成は `master ← #75 ← #76 ← #78`。本 PR は **master から独立**に
切ったブランチ。`.devcontainer/Dockerfile` は #75/#76/#78 のどのブランチでも
変更されていないため、master へ独立にマージできる。

本 PR がマージされた後の道筋:

1. 本 PR が master に入る → CI image (`:latest`) が再ビルドされ
   clang-format 14 入りになる。
2. #75 → #76 → #78 がそれぞれ最新 master を取り込む（または #78 が
   最終的に master にマージされる）と、`format.yml` は clang-format 14 の
   image 上で走る。
3. #76 の reformat も 14 で行われているため、`--dry-run --Werror` は diff
   ゼロで緑になる。

## 検証 (ローカルで担保できた範囲)

docker がこの環境に無いため image ビルド自体は回せていないが、以下を確認:

- devcontainer のローカル `clang-format` は 14.0.0、CI が使っているのは
  18.1.3（失敗ログより）。バージョン不一致を直接確認。
- `clang-format-14` で **#76 の reformat 済みツリー** に
  `git ls-files -- cc include common | grep -E '\.(cc|hh|cpp)$' | xargs clang-format-14 --dry-run --Werror`
  を実行 → **exit 0（緑）**。
- 同じく **#78 のツリー**（#76 + format.yml）でも → **exit 0（緑）**。
- `clang-format-14` パッケージが Ubuntu 24.04 noble の universe に存在する
  ことを確認（`1:14.0.6-19build4`）。

CI 本体は GitHub 上でしか回せないため、image 再ビルド後の最終確認は
マージ後の Actions に委ねる。