### PR TITLE
fix: cicada/mvto insert で TupleBody の use-after-move を解消 (#57)

### DIFF
--- a/cc/cicada/include/tuple.hh
+++ b/cc/cicada/include/tuple.hh
@@ -92,8 +92,8 @@ public:
 #endif
   }
 
-  void init([[maybe_unused]] size_t thid, Version* ver, uint64_t initial_wts,
-            [[maybe_unused]] TupleBody&& body) {
+  void init([[maybe_unused]] size_t thid, [[maybe_unused]] Version* ver,
+            uint64_t initial_wts) {
     min_wts_ = initial_wts;
     gc_lock_.store(0, std::memory_order_release);
     continuing_commit_.store(0, std::memory_order_release);

--- a/cc/cicada/transaction.cc
+++ b/cc/cicada/transaction.cc
@@ -313,7 +313,7 @@ Status TxExecutor::insert(Storage s, std::string_view key, TupleBody&& body) {
 
   tuple = new Tuple();
   Version* new_ver = newVersionGeneration(tuple, std::move(body));
-  tuple->init(this->thid_, new_ver, this->wts_.ts_, std::move(body));
+  tuple->init(this->thid_, new_ver, this->wts_.ts_);
 
   typename MasstreeWrapper<Tuple>::insert_info_t insert_info;
   Status stat =

--- a/cc/mvto/include/tuple.hh
+++ b/cc/mvto/include/tuple.hh
@@ -58,8 +58,7 @@ public:
     body_ = std::ref((latest_.load(std::memory_order_acquire))->body_);
   }
 
-  void init([[maybe_unused]] size_t thid, Version* ver, uint64_t initial_wts,
-            [[maybe_unused]] TupleBody&& body) {
+  void init([[maybe_unused]] size_t thid, Version* ver, uint64_t initial_wts) {
     min_wts_ = initial_wts;
     gc_lock_.store(0, std::memory_order_release);
     latest_.store(ver, std::memory_order_release);

--- a/cc/mvto/transaction.cc
+++ b/cc/mvto/transaction.cc
@@ -167,7 +167,7 @@ Status TxExecutor::insert(Storage s, std::string_view key, TupleBody&& body) {
 
   tuple = new Tuple();
   Version* new_ver = newVersionGeneration(tuple, std::move(body));
-  tuple->init(this->thid_, new_ver, this->wts_.ts_, std::move(body));
+  tuple->init(this->thid_, new_ver, this->wts_.ts_);
 
   Status stat = Masstrees[get_storage(s)].insert_value(key, tuple);
   if (stat == Status::WARN_ALREADY_EXISTS) {


### PR DESCRIPTION
## Summary
- cicada/mvto の `TxExecutor::insert` で `Tuple::init()` 4 引数 overload に `std::move(body)` を 2 度渡していた use-after-move を解消
- Issue #57 の Intent B (推奨案) に従い、`init()` から未使用の `TupleBody&& body` 引数を削除し、呼び出し側も 3 引数化
- `INLINE_VERSION_OPT_CICADA=1` で insert 系トランザクションを走らせた際のデータロス経路の遠因となるコードスメルを除去

Closes #57

## Test plan
- [ ] CI (GCC 13) で cicada と mvto の全 workload (Release+Debug+ASan) がグリーンになる
- [x] ローカルで `bomb_cicada.exe -extime=1` / `bomb_mvto.exe -extime=1` が Debug+ASan で正常完了 (cicada 85619 tps, mvto 97042 tps)
- [x] `INLINE_VERSION_OPT_CICADA=1` でビルドが通る (default の `INLINE_VERSION_PROMOTION` との組み合わせは pre-existing な別バグがあり今回は対象外)