### PR TITLE
p8: bootstrap 残骸を撤去して #99 を closing

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,23 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-git submodule update --init --recursive
-
 cat <<'EOF'
 
 ============================================================
 ccbench devcontainer is ready.
 
-Next steps (run these inside the container):
-
-  ./build_tools/bootstrap.sh             # build masstree
-  ./build_tools/bootstrap_mimalloc.sh    # build mimalloc
-  ./build_tools/bootstrap_googletest.sh  # build googletest
-
-Then build everything in one shot from the repo root:
+Build everything in one shot from the repo root:
 
   cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
   cmake --build build -j
+
+CMake's FetchContent fetches and builds the third-party deps
+(masstree, mimalloc, googletest) at configure time.
 
 Or build a single protocol target, e.g.:
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ See [docs/workloads_en.md](docs/workloads_en.md) for the workload specs (tables,
 
 ## Quick start (devcontainer)
 
-The repo ships with a `linux/amd64` devcontainer at [.devcontainer/](.devcontainer/) that pulls a prebuilt image from GHCR. In VS Code, run **`Dev Containers: Reopen in Container`** — submodules and apt deps are set up automatically.
+The repo ships with a `linux/amd64` devcontainer at [.devcontainer/](.devcontainer/) that pulls a prebuilt image from GHCR. In VS Code, run **`Dev Containers: Reopen in Container`** — apt deps are set up automatically.
 
 Then inside the container:
 
 ```sh
-./build_tools/bootstrap.sh             # masstree
-./build_tools/bootstrap_mimalloc.sh    # mimalloc
-./build_tools/bootstrap_googletest.sh  # googletest
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 ```
+
+CMake's FetchContent fetches and builds the third-party dependencies
+(`masstree`, `mimalloc`, `googletest`) at configure time.
 
 > On Apple Silicon the container runs under QEMU emulation: fine for development, **not** for benchmark numbers. Use a real x86_64 Linux host for measurements. See [docs/build_en.md](docs/build_en.md) for the full host setup.
 

--- a/build_tools/bootstrap_apt.sh
+++ b/build_tools/bootstrap_apt.sh
@@ -1,2 +1,0 @@
-sudo apt update -y
-sudo apt install -y libgflags-dev cmake cmake-curses-gui libboost-filesystem-dev

--- a/build_tools/ubuntu.deps
+++ b/build_tools/ubuntu.deps
@@ -1,5 +1,4 @@
 g++
-autoconf
 cmake cmake-curses-gui
 libboost-filesystem-dev
 libgflags-dev

--- a/docs/architecture_en.md
+++ b/docs/architecture_en.md
@@ -21,9 +21,8 @@ Workload specs are in [workloads.md](workloads_en.md).
 - [include/ycsb.hh](../include/ycsb.hh), [include/bomb.hh](../include/bomb.hh), [include/bomb_pessimistic.hh](../include/bomb_pessimistic.hh), [include/dbomb_deterministic.hh](../include/dbomb_deterministic.hh), [include/sbomb_deterministic.hh](../include/sbomb_deterministic.hh), [include/workload.hh](../include/workload.hh) — workload entry points
 - [common/](../common/) — shared sources used across protocols
 - [cc/](../cc/) — one subdirectory per concurrency control protocol (`cc/silo/`, `cc/cicada/`, …), each with a single-call `CMakeLists.txt` and the `<workload>_<protocol>.cc` entry points
-- [third_party/](../third_party/) — submodules: `masstree`, `mimalloc`, `googletest`
-- [build_tools/](../build_tools/) — bootstrap scripts and `ubuntu.deps` (apt package list)
-- [cmake/](../cmake/) — shared CMake modules: `CompileOptions.cmake`, [Options.cmake](../cmake/Options.cmake) (universal `-D` flags), [ProtocolHelpers.cmake](../cmake/ProtocolHelpers.cmake) (`ccbench_add_protocol`)
+- [build_tools/](../build_tools/) — `ubuntu.deps` (apt package list)
+- [cmake/](../cmake/) — shared CMake modules: `CompileOptions.cmake`, [Options.cmake](../cmake/Options.cmake) (universal `-D` flags), [ProtocolHelpers.cmake](../cmake/ProtocolHelpers.cmake) (`ccbench_add_protocol`), [ThirdParty.cmake](../cmake/ThirdParty.cmake) (fetches `masstree` / `mimalloc` / `googletest` via FetchContent)
 - [docs/](.) — this directory
 - [microbench/](../microbench/) — microbenchmarks measuring the cost of instructions / operations (`fetch_add`, `membench`, etc.); not built by default, opt in with `-DCCBENCH_BUILD_MICROBENCH=ON`
 

--- a/docs/architecture_ja.md
+++ b/docs/architecture_ja.md
@@ -21,9 +21,8 @@ CCBench は主要な in-memory 並行性制御プロトコルを **共通の基�
 - [include/ycsb.hh](../include/ycsb.hh), [include/bomb.hh](../include/bomb.hh), [include/bomb_pessimistic.hh](../include/bomb_pessimistic.hh), [include/dbomb_deterministic.hh](../include/dbomb_deterministic.hh), [include/sbomb_deterministic.hh](../include/sbomb_deterministic.hh), [include/workload.hh](../include/workload.hh) — 各ワークロードのエントリポイント
 - [common/](../common/) — 全プロトコル共通のソース
 - [cc/](../cc/) — 各 CC プロトコルのサブディレクトリ (`cc/silo/`, `cc/cicada/`, ...)。各々 1 行で済む `CMakeLists.txt` と `<workload>_<protocol>.cc` のエントリポイントを持つ
-- [third_party/](../third_party/) — submodules: `masstree`, `mimalloc`, `googletest`
-- [build_tools/](../build_tools/) — bootstrap スクリプトと `ubuntu.deps` (apt パッケージリスト)
-- [cmake/](../cmake/) — 共有 CMake モジュール: `CompileOptions.cmake`、[Options.cmake](../cmake/Options.cmake) (汎用の `-D` フラグ群)、[ProtocolHelpers.cmake](../cmake/ProtocolHelpers.cmake) (`ccbench_add_protocol`)
+- [build_tools/](../build_tools/) — `ubuntu.deps` (apt パッケージリスト)
+- [cmake/](../cmake/) — 共有 CMake モジュール: `CompileOptions.cmake`、[Options.cmake](../cmake/Options.cmake) (汎用の `-D` フラグ群)、[ProtocolHelpers.cmake](../cmake/ProtocolHelpers.cmake) (`ccbench_add_protocol`)、[ThirdParty.cmake](../cmake/ThirdParty.cmake) (`masstree` / `mimalloc` / `googletest` を FetchContent で取得)
 - [docs/](.) — このディレクトリ
 - [microbench/](../microbench/) — 命令・操作のコストを測るマイクロベンチ (`fetch_add`, `membench`, など)。デフォルトではビルドされず、`-DCCBENCH_BUILD_MICROBENCH=ON` でオプトイン
 

--- a/docs/build_en.md
+++ b/docs/build_en.md
@@ -10,8 +10,7 @@ on macOS, use the [devcontainer](#devcontainer-on-macos--non-ubuntu-hosts).
 
 CI runs on GitHub Actions `ubuntu-latest` — see
 [.github/workflows/build.yml](../.github/workflows/build.yml). It triggers
-on push to any branch and on PRs; ccache + apt + bootstrap output are all
-cached.
+on push to any branch and on PRs; ccache and apt are cached.
 
 Install build dependencies (this is what CI uses):
 
@@ -19,20 +18,6 @@ Install build dependencies (this is what CI uses):
 sudo apt-get update
 sudo apt-get install -y $(cat build_tools/ubuntu.deps)
 ```
-
-## Third-party libraries
-
-These produce static libraries under `third_party/` that the protocols link
-against. Run them once after cloning:
-
-```sh
-./build_tools/bootstrap.sh             # third_party/masstree
-./build_tools/bootstrap_mimalloc.sh    # third_party/mimalloc
-./build_tools/bootstrap_googletest.sh  # third_party/googletest
-```
-
-If a binary fails to find mimalloc at runtime, add
-`third_party/mimalloc/out/release/` to `LD_LIBRARY_PATH`.
 
 ## Building everything (top-level CMake)
 
@@ -101,10 +86,9 @@ The repo ships a devcontainer at [.devcontainer/](../.devcontainer/) pinned
 to `linux/amd64`:
 
 1. Open the repo in VS Code and run **Dev Containers: Reopen in Container**.
-2. The post-create hook runs `git submodule update --init --recursive` and
-   prints the next-step commands.
-3. Inside the container, run the three bootstrap scripts above and the
-   top-level `cmake -S . -B build` build.
+2. Inside the container, run the top-level
+   `cmake -S . -B build && cmake --build build`. CMake's FetchContent
+   fetches and builds the third-party dependencies at configure time.
 
 The image is published to `ghcr.io/thawk105/ccbench-devcontainer:latest` and
 rebuilt by [.github/workflows/devcontainer-image.yml](../.github/workflows/devcontainer-image.yml)

--- a/docs/build_ja.md
+++ b/docs/build_ja.md
@@ -4,7 +4,7 @@
 
 CCBench は x86_64 Linux (Debian/Ubuntu) を対象とする。x86 intrinsics (`__cpuid_count` in [include/cpu.hh](../include/cpu.hh)) と Linux 専用 API (`sched_setaffinity`, `SYS_gettid`, `<linux/fs.h>` in [include/fileio.hh](../include/fileio.hh)) を使うので、macOS など他のプラットフォームでネイティブにはビルドできない。macOS で開発する場合は [devcontainer](#devcontainer-macos--ubuntu-以外のホスト向け) を使う。
 
-CI は GitHub Actions の `ubuntu-latest` で走る — [.github/workflows/build.yml](../.github/workflows/build.yml) 参照。push (どのブランチでも) と PR でトリガーされ、ccache + apt + bootstrap output は全部キャッシュされる。
+CI は GitHub Actions の `ubuntu-latest` で走る — [.github/workflows/build.yml](../.github/workflows/build.yml) 参照。push (どのブランチでも) と PR でトリガーされ、ccache と apt はキャッシュされる。
 
 ビルド依存をインストール (CI もこれを使っている):
 
@@ -12,18 +12,6 @@ CI は GitHub Actions の `ubuntu-latest` で走る — [.github/workflows/build
 sudo apt-get update
 sudo apt-get install -y $(cat build_tools/ubuntu.deps)
 ```
-
-## サードパーティライブラリ
-
-`third_party/` 配下の静的ライブラリを生成する。プロトコルがリンクする対象。clone 後に一度だけ実行:
-
-```sh
-./build_tools/bootstrap.sh             # third_party/masstree
-./build_tools/bootstrap_mimalloc.sh    # third_party/mimalloc
-./build_tools/bootstrap_googletest.sh  # third_party/googletest
-```
-
-実行時に mimalloc が見つからないというエラーが出たら、`third_party/mimalloc/out/release/` を `LD_LIBRARY_PATH` に追加する。
 
 ## 全部ビルドする (トップレベル CMake)
 
@@ -66,8 +54,7 @@ devcontainer (`ubuntu:24.04` ベース、[.devcontainer/Dockerfile](../.devconta
 リポジトリは `linux/amd64` に pin した devcontainer ([.devcontainer/](../.devcontainer/)) を同梱している:
 
 1. VS Code でリポジトリを開いて **Dev Containers: Reopen in Container** を実行
-2. post-create hook が `git submodule update --init --recursive` を実行し、次の手順コマンドを表示する
-3. コンテナ内で上記の 3 つの bootstrap スクリプトとトップレベル `cmake -S . -B build` を実行
+2. コンテナ内でトップレベル `cmake -S . -B build && cmake --build build` を実行 (サードパーティ依存は CMake の FetchContent が configure 時に自動取得・ビルドする)
 
 image は `ghcr.io/thawk105/ccbench-devcontainer:latest` に publish されていて、`.devcontainer/` を変更するたびに [.github/workflows/devcontainer-image.yml](../.github/workflows/devcontainer-image.yml) で rebuild される。
 


### PR DESCRIPTION
## Summary

- `build_tools/bootstrap_apt.sh` ラッパ (`ubuntu.deps` を `xargs apt-get install` に投げるだけのスクリプト) を削除し、`build_tools/ubuntu.deps` は手動 `apt install` でそのまま流せる shopping list として残置。
- `docs/build_{ja,en}.md` を「3 本の bootstrap スクリプト + submodule init」前提から `cmake -S . -B build && cmake --build build` 完結のフローに書き換え (CI キャッシュ説明の `bootstrap output` 言及も同期)。
- `docs/architecture_{ja,en}.md` のレイアウト記述・`README.md`・`.devcontainer/post-create.sh` を FetchContent ベースに合わせて整合。

PR #109 (MERGED) で完了済みの 3 ライブラリ FetchContent 移行 (masstree / mimalloc / googletest) の仕上げ。CLAUDE.md ハードルール#5 に従い `_ja` / `_en` を同一 commit で更新。

### 補足: `autoconf` は残置

当初 `ubuntu.deps` から `autoconf` も削除したが (commit `a848508`)、`cmake/ThirdParty.cmake` (L66-L77) が今も masstree 上流の `./bootstrap.sh` (= autoreconf) を `add_custom_command` 経由で起動するため `autoconf` は **依然として必須**。host build が壊れるので follow-up commit (`c759ceb`) で復活させた。`ubuntu.deps` は PR #111 前と同内容。

### フォローアップ提案 (別 issue 化想定)

masstree 上流には commit 済みの `configure` (autoreconf 出力) が同梱されており、bootstrap.sh が呼ぶ autoreconf は本来不要。`ThirdParty.cmake` の `./bootstrap.sh` 呼び出しを撤去して `./configure` を直叩きにすれば、`ubuntu.deps` / devcontainer Dockerfile の双方から `autoconf` (および間接依存の `automake` / `libtool` / `pkg-config`) を落とせる。Issue #99 のスコープを越えるので本 PR には含めず別 issue で対応する。

## Test plan

- [ ] `docs/build_{ja,en}.md` / `docs/architecture_{ja,en}.md` が submodule / bootstrap 言及なしの記述に揃っていること (`_ja` / `_en` セット)
- [ ] CI `build` ジョブがグリーン (devcontainer image 経由)
- [ ] `.github/workflows/format.yml` は `docs/**` / `.devcontainer/**` を `paths-ignore` にしているので、本 PR ではトリガーされないことを確認
- [ ] `ubuntu.deps` の内容が PR 前と同じ (autoconf 行を含む) こと

Closes #99
