### PR TITLE
build: shirakami を third_party/shirakami サブモジュールとして追加

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/shirakami"]
+	path = third_party/shirakami
+	url = https://github.com/thawk105/shirakami.git


### PR DESCRIPTION
## Summary

- ycsb / tpcc ベンチマークの比較対象として [thawk105/shirakami](https://github.com/thawk105/shirakami) を `third_party/shirakami` に submodule で追加
- 配置は `cc/` ではなく `third_party/`: `cc/` は ccbench の `TxExecutor` 契約を実装した in-tree プロトコル置き場であり、外部エンジンを置くと意味が混ざるため
- pin 先は upstream master `fb14e65`

## 設計メモ

- shirakami は独立したトランザクションエンジン (独自 CMake / bench / test 持ち) なので、`#97` / `#98` で submodule → FetchContent 移行した gtest / masstree / mimalloc / spdlog (passive な build dep) とは位置付けが違う。ピン留めしたい比較ターゲットなので submodule で扱う方針
- ccbench への組み込みは「`third_party/shirakami/` = upstream そのまま」「`cc/shirakami/` (本 PR では作らない) = `TxExecutor` を実装する adapter で shirakami の API を呼ぶ」の二層構成を想定。これにより既存の `common/runner.hh` テンプレート (#102) からシームレスに駆動できる

## Out of scope (別 PR)

- `cc/shirakami/` の TxExecutor adapter 実装
- CI workflow の `actions/checkout` に `submodules: recursive` を追加
- [docs/protocols_ja.md](docs/protocols_ja.md) / [docs/build_ja.md](docs/build_ja.md) の更新 (clone 手順、submodule init コマンドなど、`_ja`/`_en` セット)

## Test plan

- [ ] `git submodule update --init --recursive` で shirakami が clone されること
- [ ] 既存 build (cc/* / microbench / tpcc_silo) に影響がないこと
- [ ] `.gitmodules` の path と section name が `third_party/shirakami` で一致していること