### PR TITLE
Fix WAL log preallocation: 10 ^ 9 (XOR=3) -> 1000000000

### DIFF
--- a/cc/silo/bomb_silo.cc
+++ b/cc/silo/bomb_silo.cc
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) try {
         std::string logpath;
         genLogFile(logpath, thid);
         trans.logfile_.open(logpath, O_CREAT | O_TRUNC | O_WRONLY, 0644);
-        trans.logfile_.ftruncate(10 ^ 9);
+        trans.logfile_.ftruncate(1000000000);
 #else
         (void) trans;
 #endif

--- a/cc/silo/sbomb_silo.cc
+++ b/cc/silo/sbomb_silo.cc
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) try {
         std::string logpath;
         genLogFile(logpath, thid);
         trans.logfile_.open(logpath, O_CREAT | O_TRUNC | O_WRONLY, 0644);
-        trans.logfile_.ftruncate(10 ^ 9);
+        trans.logfile_.ftruncate(1000000000);
 #else
         (void) trans;
 #endif

--- a/cc/silo/tpcc_silo.cc
+++ b/cc/silo/tpcc_silo.cc
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) try {
         std::string logpath;
         genLogFile(logpath, thid);
         trans.logfile_.open(logpath, O_CREAT | O_TRUNC | O_WRONLY, 0644);
-        trans.logfile_.ftruncate(10 ^ 9);
+        trans.logfile_.ftruncate(1000000000);
 #else
         (void) trans;
 #endif

--- a/cc/silo/ycsb_silo.cc
+++ b/cc/silo/ycsb_silo.cc
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) try {
         std::string logpath;
         genLogFile(logpath, thid);
         trans.logfile_.open(logpath, O_CREAT | O_TRUNC | O_WRONLY, 0644);
-        trans.logfile_.ftruncate(10 ^ 9);
+        trans.logfile_.ftruncate(1000000000);
 #else
         (void) trans;
 #endif

--- a/cc/ss2pl/bomb_ss2pl.cc
+++ b/cc/ss2pl/bomb_ss2pl.cc
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) try {
         std::string logpath;
         genLogFile(logpath, thid);
         trans.logfile_.open(logpath, O_CREAT | O_TRUNC | O_WRONLY, 0644);
-        trans.logfile_.ftruncate(10 ^ 9);
+        trans.logfile_.ftruncate(1000000000);
 #else
         (void) trans;
 #endif


### PR DESCRIPTION
`ftruncate(10 ^ 9)` is a bitwise XOR yielding 3 bytes, not the intended 1e9 (1 GB) log preallocation. It also fails gcc-13 -Werror=xor-used-as-pow. Affects silo (ycsb/sbomb/tpcc/bomb) and ss2pl (bomb) under `#if WAL`.

Found via Izanagi parameter-space full enumeration: the WAL code path is not compiled in default WAL=0 builds, so this stayed latent until WAL=1 was exercised across the optimization-flag hypercube.