### PR TITLE
ODR違反の修正: ccbench_common を universal definitions 付きでビルドする

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 # set_compile_options() — applied to ccbench_common here and to every
 # protocol binary via ccbench_add_protocol() (see cmake/CompileOptions.cmake).
 include(CompileOptions)
+# Options defines ccbench_universal_definitions(); ProtocolHelpers also includes
+# it, but ccbench_common (below) needs the universal defines too (see comment
+# there), so pull it in early. include() is idempotent for these cache/function
+# defs.
+include(Options)
 
 option(ENABLE_SANITIZER "enable sanitizer on debug build" ON)
 option(ENABLE_UB_SANITIZER "enable undefined behavior sanitizer on debug build" OFF)
@@ -48,6 +53,17 @@ add_library(ccbench_common STATIC
   common/util.cc
 )
 target_compile_features(ccbench_common PUBLIC cxx_std_20)
+# ccbench_common compiles common/result.cc, which defines and resize()s the
+# global CCBenchResults (std::vector<Result>). The Result struct grows under
+# `#if ADD_ANALYSIS` (and other universal flags can affect shared layout/behavior),
+# so ccbench_common MUST see the same universal definitions as the protocol
+# targets that link it. Without this, ccbench_common built Result with the
+# default flags (e.g. ADD_ANALYSIS=0 -> small Result) while a protocol built with
+# ADD_ANALYSIS=1 iterated CCBenchResults with the larger stride -> ODR violation /
+# heap-buffer-overflow (e.g. BACK_OFF=1 + ADD_ANALYSIS=1 crashed in
+# leaderBackoffWork's range-for over CCBenchResults).
+ccbench_universal_definitions(_common_universal_defs)
+target_compile_definitions(ccbench_common PRIVATE ${_common_universal_defs})
 set_compile_options(ccbench_common)
 target_include_directories(ccbench_common PUBLIC
   ${CMAKE_SOURCE_DIR}

--- a/common/result.cc
+++ b/common/result.cc
@@ -411,7 +411,10 @@ void Result::displayCycleCheckCount() {
 }
 
 void Result::displayForwardingCount() {
-  uint64_t num_txns = total_commit_counts_ + total_abort_counts_;
+  // num_txns is only referenced by the commented-out per-tx rate below; keep it
+  // (preserving the author's intent) but mark maybe_unused so -Werror is happy.
+  [[maybe_unused]] uint64_t num_txns =
+      total_commit_counts_ + total_abort_counts_;
   auto n = total_forwarding1_count_; // / (long double)num_txns;
   cout << "1st_forwarding_count: " << n << endl;
   auto m = total_forwarding2_count_; // / (long double)num_txns;


### PR DESCRIPTION
## 問題
`CCBENCH_BACK_OFF=1` と `CCBENCH_ADD_ANALYSIS=1` を同時指定したビルドが、起動直後の
`TxExecutor::leaderWork()` で必ず segfault します（スレッド数非依存）。`BACK_OFF=1`
単体・`ADD_ANALYSIS=1` 単体ではどちらも正常です。

## 根本原因（ODR 違反）
`Result` のレイアウトは `#if ADD_ANALYSIS` でフィールドが増え `sizeof(Result)` が変わります。
グローバルの `CCBenchResults`（`std::vector<Result>`）を定義・`resize()` するのは
`common/result.cc` で、これは `ccbench_common` 静的ライブラリにコンパイルされます。

ところが `ccbench_common` は **universal な `CCBENCH_*` 定義を一切受けずに**ビルドされて
いました。プロトコル各ターゲットは `ccbench_add_protocol()` 経由で
`target_compile_definitions(... PRIVATE ...)` として受け取りますが、`ccbench_common` は
`set_compile_options()`（警告/標準のみ）しか受けません。

その結果 `ADD_ANALYSIS=1` のとき:
- `ccbench_common` は `Result` を `ADD_ANALYSIS=0`（小レイアウト）でコンパイルし、小さい
  stride で `resize()` する。
- プロトコル側（silo 等）は `ADD_ANALYSIS=1`（大レイアウト）でコンパイルし、
  `leaderBackoffWork()` の range-for が大きい stride で `CCBenchResults` を走査する。

`end()` は小 stride で設定されているため、大 stride のループが要素1つ分 buffer 末尾を
追い越して読み、**heap-buffer-overflow** になります。`BACK_OFF=1` のときだけ顕在化するのは、
プロトコル側が `CCBenchResults` を走査する唯一の箇所 `leaderBackoffWork()` が `#if BACK_OFF`
内にあるためです。

AddressSanitizer:
heap-buffer-overflow ... READ of size 8
#0 loadAcquire<uint64_t>     include/atomic_wrapper.hh:34
#1 leaderBackoffWork(...)    include/backoff.hh:124
#2 TxExecutor::leaderWork()  cc/silo/transaction.cc:597
... buffer allocated by:
#7 initResult(...)           common/result.cc:26   (CCBenchResults.resize)



## 修正
1. `CMakeLists.txt`: `ccbench_common` に `ccbench_universal_definitions()` を適用し、
   リンクするプロトコルと同じ `ADD_ANALYSIS`（および他の universal フラグ）を見せる。
   `ccbench_common` 定義時にヘルパが必要なので `include(Options)` を早めに追加。
2. `common/result.cc`: 上記で `#if ADD_ANALYSIS` 専用の `displayForwardingCount()` が初めて
   コンパイルされ、dead 変数 `num_txns`（使用箇所が全てコメントアウト）が
   `-Werror=unused-variable` に引っかかるので `[[maybe_unused]]` を付与。

## 検証（gcc-13）
- `BACK_OFF=1 + ADD_ANALYSIS=1` が ASan clean で動作し `backoff_latency_rate` を出力。
- default（`ADD_ANALYSIS=0`）および Release `-Werror` ビルドは無影響（silo は 48 スレッドで
  従来どおり完走）。

## 再現（修正前）
cmake -S . -B build-aa -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZER=ON 

-DCCBENCH_BACK_OFF=1 -DCCBENCH_ADD_ANALYSIS=1
cmake --build build-aa --target ycsb_silo.exe
build-aa/cc/silo/ycsb_silo.exe -thread_num=1 -ycsb_tuple_num=10000 -extime=1